### PR TITLE
07locale.t - sync up #skips with #tests

### DIFF
--- a/t/07locale.t
+++ b/t/07locale.t
@@ -15,8 +15,8 @@ BEGIN {
 }
 
 SKIP: {
-	skip 'No locale testing for Perl < 5.6.0', 6 if $] < 5.006;
-	skip 'No locale testing without d_setlocale', 6
+	skip 'No locale testing for Perl < 5.6.0', 7 if $] < 5.006;
+	skip 'No locale testing without d_setlocale', 7
 	    if(!$Config{d_setlocale});
 
 	# test locale handling


### PR DESCRIPTION
In 07locale.t, the number of tests to be skipped if Perl < 5.6.0 or d_setlocale=undef looks to have fallen out of sync with the number of tests in the file.

Currently trying to build on a system without d_setlocale:
```
$ ./perl -T -Ilib cpan/version/t/07locale.t
1..8
ok 1 - use version;
ok 2 # skip No locale testing without d_setlocale
ok 3 # skip No locale testing without d_setlocale
ok 4 # skip No locale testing without d_setlocale
ok 5 # skip No locale testing without d_setlocale
ok 6 # skip No locale testing without d_setlocale
ok 7 # skip No locale testing without d_setlocale
# Looks like you planned 8 tests but ran 7.
```

The intention of the skip lines at the top of the SKIP:{} block looks to be to skip all remaining tests, but these lines skip 6 tests when there are 7 tests remaining. 

(Looks like when the TODO: block was added in somewhere between 0.9909 and 0.9914, the number of tests to skip didn't get bumped.)