### PR TITLE
Remove use of SvCUR() as lvalue

### DIFF
--- a/vutil/vutil.c
+++ b/vutil/vutil.c
@@ -533,7 +533,7 @@ Perl_new_version(pTHX_ SV *ver)
 	    under = ninstr(raw, raw+len, underscore, underscore + 1);
 	    if (under) {
 		Move(under + 1, under, raw + len - under - 1, char);
-		SvCUR(rv)--;
+		SvCUR_set(rv, SvCUR(rv) - 1);
 		*SvEND(rv) = '\0';
 	    }
 	    /* this is for consistency with the pure Perl class */


### PR DESCRIPTION
`SvCUR()` is no longer an lvalue macro under `PERL_CORE` in blead, so use `SvCUR_set()` instead.

c.f. https://perl5.git.perl.org/perl.git/commitdiff/2324bdb9a8664e4dd5b50ba32a17f9794126d2fd#patch9