### PR TITLE
Copy setlocale() return value in case it gets clobbered by later calls

### DIFF
--- a/vutil/vutil.c
+++ b/vutil/vutil.c
@@ -634,7 +634,7 @@ VER_NV:
 
             LC_NUMERIC_LOCK(0);    /* Start critical section */
 
-            locale_name_on_entry = setlocale(LC_NUMERIC, NULL);
+            locale_name_on_entry = savepv(setlocale(LC_NUMERIC, NULL));
             if (   strNE(locale_name_on_entry, "C")
                 && strNE(locale_name_on_entry, "POSIX"))
             {
@@ -642,6 +642,7 @@ VER_NV:
             }
             else {  /* This value indicates to the restore code that we didn't
                        change the locale */
+                Safefree(locale_name_on_entry);
                 locale_name_on_entry = NULL;
             }
 
@@ -710,6 +711,7 @@ VER_NV:
 
             if (locale_name_on_entry) {
                 setlocale(LC_NUMERIC, locale_name_on_entry);
+                Safefree(locale_name_on_entry);
             }
 
             LC_NUMERIC_UNLOCK;  /* End critical section */


### PR DESCRIPTION
Flagged by AddressSanitizer in [perl #134182]

Quoting IEEE Std 1003.1, 2004 Edition

 https://pubs.opengroup.org/onlinepubs/009695399/functions/setlocale.html

 The string returned by setlocale() is such that a subsequent call with
 that string and its associated category shall restore that part of the
 program's locale. The application shall not modify the string returned
 which may be overwritten by a subsequent call to setlocale().

Bug: https://rt.perl.org/Public/Bug/Display.html?id=134182