### PR TITLE
Fix unquoted string version issues with Perl 5.6

### DIFF
--- a/t/04strict_lax.t
+++ b/t/04strict_lax.t
@@ -90,7 +90,7 @@ _		fail	fail
 CASE_DATA
 
   require version;
-  version->import( qw/is_strict is_lax/ );
+  'version'->import( qw/is_strict is_lax/ );
   for my $case ( split qr/\n/, $strict_lax_data ) {
     my ($v, $strict, $lax) = split qr/\t+/, $case;
     main::ok( $strict eq 'pass' ? is_strict($v) : ! is_strict($v), "is_strict($v) [$strict]" );

--- a/t/06noop.t
+++ b/t/06noop.t
@@ -10,7 +10,7 @@ BEGIN {
     use_ok('version', 0.9925);
 }
 
-my $v1 = version->new('1.2');
+my $v1 = 'version'->new('1.2');
 eval {$v1 = $v1 + 1};
 like $@, qr/operation not supported with version object/, 'No math ops with version objects';
 eval {$v1 = $v1 - 1};

--- a/t/07locale.t
+++ b/t/07locale.t
@@ -44,7 +44,7 @@ SKIP: {
 	setlocale(LC_NUMERIC, $loc);
 	$ver = 1.23;  # has to be floating point number
 	ok ($ver eq "1,23", "Using locale: $loc");
-	$v = version->new($ver);
+	$v = 'version'->new($ver);
 	unlike($warning, qr/Version string '1,23' contains invalid data/,
 	    "Process locale-dependent floating point");
 	ok ($v eq "1.23", "Locale doesn't apply to version objects");
@@ -52,7 +52,7 @@ SKIP: {
 
         TODO: { # Resolve https://rt.cpan.org/Ticket/Display.html?id=102272
             local $TODO = 'Fails for Perl 5.x.0 < 5.19.0' if $] < 5.019000;
-            $ver = version->new($]);
+            $ver = 'version'->new($]);
             is "$ver", "$]", 'Use PV for dualvars';
         }
 	setlocale( LC_ALL, $orig_loc); # reset this before possible skip

--- a/t/coretests.pm
+++ b/t/coretests.pm
@@ -581,8 +581,8 @@ SKIP: {
 
     { # https://rt.cpan.org/Ticket/Display.html?id=88495
 	@ver::ISA = $CLASS;
-	is ref(ver->new), 'ver', 'ver can inherit from version';
-	is ref(ver->qv("1.2.3")), 'ver', 'ver can inherit from version';
+	is ref('ver'->new), 'ver', 'ver can inherit from version';
+	is ref('ver'->qv("1.2.3")), 'ver', 'ver can inherit from version';
     }
 
     { # discovered while integrating with bleadperl


### PR DESCRIPTION
This is fixing issues noticed when testing on Perl 5.6
view warnings from 5.6 build log: https://github.com/atoomic/version.pm/runs/967452562