### PR TITLE
Only load ppport.h from vutil/vutil.h

### DIFF
--- a/vutil/vutil.h
+++ b/vutil/vutil.h
@@ -1,10 +1,6 @@
 /* This file is part of the "version" CPAN distribution.  Please avoid
    editing it in the perl core. */
 
-#ifndef PERL_CORE
-#  include "ppport.h"
-#endif
-
 /* The MUTABLE_*() macros cast pointers to the types shown, in such a way
  * (compiler permitting) that casting away const-ness will give a warning;
  * e.g.:


### PR DESCRIPTION
Loading ppport.h is protected by a PERL_CORE check
The NEED_* macro need to be set before loading ppport.h