### PR TITLE
Use setpv not catpv

### DIFF
--- a/vutil/vutil.c
+++ b/vutil/vutil.c
@@ -693,7 +693,7 @@ VER_NV:
 #endif
 
 	if (sv) {
-                Perl_sv_catpvf(aTHX_ sv, "%.9" NVff, SvNVX(ver));
+                Perl_sv_setpvf(aTHX_ sv, "%.9" NVff, SvNVX(ver));
 	    len = SvCUR(sv);
 	    buf = SvPVX(sv);
 	}


### PR DESCRIPTION
For extremely large version numbers, an undefined SV is appended to.

See https://rt.perl.org/Ticket/Display.html?id=128207.

The changes to non-vutil.c have long been in blead.