### PR TITLE
use seperate conditionals for each MUTABLE_ macro rather than relying on MUTABLE_PTR

### DIFF
--- a/vutil/vutil.h
+++ b/vutil/vutil.h
@@ -223,7 +223,7 @@ const char * Perl_prescan_version(pTHX_ const char *s, bool strict, const char**
 
 
 #if PERL_VERSION_LT(5,27,9)
-#  define LC_NUMERIC_LOCK
+#  define LC_NUMERIC_LOCK(cond)
 #  define LC_NUMERIC_UNLOCK
 #  if PERL_VERSION_LT(5,19,0)
 #    undef STORE_LC_NUMERIC_SET_STANDARD

--- a/vutil/vutil.h
+++ b/vutil/vutil.h
@@ -16,12 +16,24 @@
 #  else
 #    define MUTABLE_PTR(p) ((void *) (p))
 #  endif
+#endif
 
+#ifndef MUTABLE_AV
 #  define MUTABLE_AV(p)	((AV *)MUTABLE_PTR(p))
+#endif
+#ifndef MUTABLE_CV
 #  define MUTABLE_CV(p)	((CV *)MUTABLE_PTR(p))
+#endif
+#ifndef MUTABLE_GV
 #  define MUTABLE_GV(p)	((GV *)MUTABLE_PTR(p))
+#endif
+#ifndef MUTABLE_HV
 #  define MUTABLE_HV(p)	((HV *)MUTABLE_PTR(p))
+#endif
+#ifndef MUTABLE_IO
 #  define MUTABLE_IO(p)	((IO *)MUTABLE_PTR(p))
+#endif
+#ifndef MUTABLE_SV
 #  define MUTABLE_SV(p)	((SV *)MUTABLE_PTR(p))
 #endif
 


### PR DESCRIPTION
Instead of having our backcompat definitions of MUTABLE_HV, MUTABLE_AV
etc be dependent on if MUTABLE_PTR is defined, check for each individual
macro. Newer versions of Devel::PPPort provide MUTABLE_PTR, but not the
various MUTABLE_* macros, so they wouldn't be defined when needed.

Fixes #23