### PR TITLE
Fix build time warnings for vxs.inc

### DIFF
--- a/vutil/vxs.inc
+++ b/vutil/vxs.inc
@@ -5,7 +5,7 @@
 #  define VXS_CLASS "version"
 #  define VXSp(name) XS_##name
 /* VXSXSDP = XSUB Details Proto */
-#  define VXSXSDP(x) x
+#  define VXSXSDP(x) x, 0
 #else
 #  define VXS_CLASS "version::vxs"
 #  define VXSp(name) VXS_##name


### PR DESCRIPTION
Addresses issues identified after a recent cpan sync into blead.

see perl/perl5/d88d17cb816: Move the implementation of %-, %+ into core.
Previously this could cause problems during minitest. Adds an int ix field
to struct xsub_details.

See https://github.com/Perl/perl5/issues/18202