### PR TITLE
detabify

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,53 +28,53 @@ This is not a complete list of changes.  See repository for full details:
 
 0.9924 - 2018-04-19
   * Revise CPAN metadata to advertise correct repo
-	Patch from Ed <ej_zg@hotmail.com>
+        Patch from Ed <ej_zg@hotmail.com>
 
 0.9923 - 2018-04-15
   * Add back spaces for picky C++ compilers 
-	Patch from Karl Williamson <khw@cpan.org>
+        Patch from Karl Williamson <khw@cpan.org>
 
 0.9922 - 2018-04-12
   * Switch master repo to github
 
 0.9921 - 2018-04-11
   * Silence overly compulsive GCC 7 warning
-	https://rt.cpan.org/Ticket/Display.html?id=123477
+        https://rt.cpan.org/Ticket/Display.html?id=123477
 
   * Improve docs regarding trailing zeros
-	https://rt.cpan.org/Ticket/Display.html?id=122858
+        https://rt.cpan.org/Ticket/Display.html?id=122858
 
 0.9920 - 2018-04-08
 
   * Backwards compatible locale handling
-	https://rt.cpan.org/Ticket/Display.html?id=125042
+        https://rt.cpan.org/Ticket/Display.html?id=125042
 
 0.9919 - 2018-04-08
 
   * Core improvements to locale handling
-	https://rt.cpan.org/Ticket/Display.html?id=124563
+        https://rt.cpan.org/Ticket/Display.html?id=124563
 
 0.9918 - 2017-04-15
 
   * Fix compiling under C++11
-	https://rt.cpan.org/Ticket/Display.html?id=118846
+        https://rt.cpan.org/Ticket/Display.html?id=118846
 
   * Make version::regex variables public for better reuse
-	https://rt.cpan.org/Ticket/Display.html?id=119669
+        https://rt.cpan.org/Ticket/Display.html?id=119669
 
   * Use rel2abs for require in tests to support 5.26.0 @INC
-	https://rt.cpan.org/Ticket/Display.html?id=121148
+        https://rt.cpan.org/Ticket/Display.html?id=121148
 
   * Move change list to standard CHANGES out of README
-	https://rt.cpan.org/Ticket/Display.html?id=119123
+        https://rt.cpan.org/Ticket/Display.html?id=119123
 
   * Better taint handling for Perl < 5.17.2 with tests
-	https://rt.cpan.org/Ticket/Display.html?id=118087
+        https://rt.cpan.org/Ticket/Display.html?id=118087
 
 0.9917 - 2016-05-29
 
   * Fix version::regex captures, resolves:
-	https://rt.cpan.org/Ticket/Display.html?id=114712
+        https://rt.cpan.org/Ticket/Display.html?id=114712
 
 0.9916 - 2016-03-18
 
@@ -125,37 +125,37 @@ This is not a complete list of changes.  See repository for full details:
 0.9912_02 - 2016-01-03
 
   * Fix stupid mistake in locale tests, resolves:
-	https://rt.cpan.org/Ticket/Display.html?id=110852
+        https://rt.cpan.org/Ticket/Display.html?id=110852
 
 0.9912_01 - 2015-12-31
 
   * Apply patch to implement Lyon Consensus:
-	https://gist.github.com/dagolden/9559280
+        https://gist.github.com/dagolden/9559280
 
   * Also resolve the following tickets:
-	https://rt.cpan.org/Ticket/Display.html?id=101647
-	https://rt.cpan.org/Ticket/Display.html?id=101841
-	https://rt.cpan.org/Ticket/Display.html?id=105315
-	https://rt.cpan.org/Ticket/Display.html?id=106782
-	https://rt.cpan.org/Ticket/Display.html?id=107113
-	https://rt.cpan.org/Ticket/Display.html?id=107114
-	https://rt.cpan.org/Ticket/Display.html?id=98744
-	https://rt.cpan.org/Ticket/Display.html?id=102272
+        https://rt.cpan.org/Ticket/Display.html?id=101647
+        https://rt.cpan.org/Ticket/Display.html?id=101841
+        https://rt.cpan.org/Ticket/Display.html?id=105315
+        https://rt.cpan.org/Ticket/Display.html?id=106782
+        https://rt.cpan.org/Ticket/Display.html?id=107113
+        https://rt.cpan.org/Ticket/Display.html?id=107114
+        https://rt.cpan.org/Ticket/Display.html?id=98744
+        https://rt.cpan.org/Ticket/Display.html?id=102272
 
 0.9912 - 2015-01-20
 
   * Complete reverting the ill-conceived alpha->normal() code, resolves:
 
-	https://rt.cpan.org/Ticket/Display.html?id=101632
+        https://rt.cpan.org/Ticket/Display.html?id=101632
 
   * Skip leading zeros when parsing dotted-decimal versions after the
     first element, resolves:
 
-	https://rt.cpan.org/Ticket/Display.html?id=101628
+        https://rt.cpan.org/Ticket/Display.html?id=101628
 
   * Minor change to report the correct rt.cpan.org URL, resolves:
 
-	https://rt.cpan.org/Public/Bug/Display.html?id=101600
+        https://rt.cpan.org/Public/Bug/Display.html?id=101600
 
 0.9911 - 2015-01-17
 
@@ -170,18 +170,18 @@ This is not a complete list of changes.  See repository for full details:
 
     Resolves:
 
-	https://rt.cpan.org/Ticket/Display.html?id=93603
-	https://rt.cpan.org/Ticket/Display.html?id=93715
-	https://rt.cpan.org/Ticket/Display.html?id=93721
-	https://rt.cpan.org/Ticket/Display.html?id=95896
-	https://rt.cpan.org/Ticket/Display.html?id=96100
-	https://rt.cpan.org/Ticket/Display.html?id=96620
-	https://rt.cpan.org/Ticket/Display.html?id=96699
+        https://rt.cpan.org/Ticket/Display.html?id=93603
+        https://rt.cpan.org/Ticket/Display.html?id=93715
+        https://rt.cpan.org/Ticket/Display.html?id=93721
+        https://rt.cpan.org/Ticket/Display.html?id=95896
+        https://rt.cpan.org/Ticket/Display.html?id=96100
+        https://rt.cpan.org/Ticket/Display.html?id=96620
+        https://rt.cpan.org/Ticket/Display.html?id=96699
 
   * Patch from Dave Mitchell to rewrite the parser and avoid warnings
     from clang.  Resolves
 
-	https://rt.cpan.org/Ticket/Display.html?id=101501
+        https://rt.cpan.org/Ticket/Display.html?id=101501
 
 0.9909 - 2014-08-15
 
@@ -194,9 +194,9 @@ This is not a complete list of changes.  See repository for full details:
 
   * More optimizations courtesy of Daniel Dragan (bulk88@hotmail.com).
     Also resolves:
-	https://rt.cpan.org/Ticket/Display.html?id=92438
-	https://rt.cpan.org/Ticket/Display.html?id=92540
-	https://rt.cpan.org/Ticket/Display.html?id=92642
+        https://rt.cpan.org/Ticket/Display.html?id=92438
+        https://rt.cpan.org/Ticket/Display.html?id=92540
+        https://rt.cpan.org/Ticket/Display.html?id=92642
 
 0.9907 - 2014-01-12
 
@@ -204,19 +204,19 @@ This is not a complete list of changes.  See repository for full details:
     (bulk88@hotmail.com).  Lots of minor tweaks as well.
 
     Resolves:
-	https://rt.cpan.org/Ticket/Display.html?id=91892
-	https://rt.cpan.org/Ticket/Display.html?id=91867
-	https://rt.cpan.org/Ticket/Display.html?id=91987
-	https://rt.cpan.org/Ticket/Display.html?id=92051
+        https://rt.cpan.org/Ticket/Display.html?id=91892
+        https://rt.cpan.org/Ticket/Display.html?id=91867
+        https://rt.cpan.org/Ticket/Display.html?id=91987
+        https://rt.cpan.org/Ticket/Display.html?id=92051
 
 0.9906 - 2014-01-04
 
   * Applied C89 compatibility fix from Karl Williamson to vxs.inc.  Added back
     support for $version::LAX and $version::STRICT to resolve:
 
-	https://rt.cpan.org/Ticket/Display.html?id=88458
-	https://rt.cpan.org/Ticket/Display.html?id=91858
-	https://rt.cpan.org/Ticket/Display.html?id=91868
+        https://rt.cpan.org/Ticket/Display.html?id=88458
+        https://rt.cpan.org/Ticket/Display.html?id=91858
+        https://rt.cpan.org/Ticket/Display.html?id=91868
 
 0.9905 - 2014-01-04
 
@@ -233,8 +233,8 @@ This is not a complete list of changes.  See repository for full details:
 
   * Final upstream changes from bleadperl.  Resolves RT tickets:
 
-	https://rt.cpan.org/Ticket/Display.html?id=87513
-	https://rt.cpan.org/Ticket/Display.html?id=87983
+        https://rt.cpan.org/Ticket/Display.html?id=87513
+        https://rt.cpan.org/Ticket/Display.html?id=87983
 
 0.9903 - 2013-08-18
 
@@ -274,29 +274,29 @@ This is not a complete list of changes.  See repository for full details:
   * Restore compatibility in replacement UNIVERSAL::VERSION with the behavior
     of Perl 5.14.x, essentially by reverting the changes in 
 
-	https://rt.perl.org/rt3/Ticket/Display.html?id=95544
+        https://rt.perl.org/rt3/Ticket/Display.html?id=95544
 
   * Fix segfault error with strings that begin with 'v', especially the string
     'version'.  Resolves:
 
-	https://rt.cpan.org/Ticket/Display.html?id=72365
+        https://rt.cpan.org/Ticket/Display.html?id=72365
 
   * Forbid all math operations on version objects in base class (this was
     already the case for XS code but the pure Perl was lacking).  Resolves:
 
-	https://rt.cpan.org/Public/Bug/Display.html?id=70950
+        https://rt.cpan.org/Public/Bug/Display.html?id=70950
 
 0.94 - 2011-08-21
 
   * Clarify documentation on advisability of using leading 'v' (it isn't
     mandatory, but it is much more likely to DTRT).  Resolves:
 
-	https://rt.cpan.org/Public/Bug/Display.html?id=70120
+        https://rt.cpan.org/Public/Bug/Display.html?id=70120
 
   * Use a localized DIE handler when attempting to load the XS code, in case
     the caller has its own DIE handler.  Resolves:
 
-	https://rt.cpan.org/Public/Bug/Display.html?id=70260
+        https://rt.cpan.org/Public/Bug/Display.html?id=70260
 
 0.93 - 2011-07-27
 
@@ -307,7 +307,7 @@ This is not a complete list of changes.  See repository for full details:
   * Forbid negative versions.  Make replacement UNIVERSAL::VERSION return the
     original $VERSION scalar if called without a requested version.  Resolves
 
-      https://rt.perl.org/rt3/Ticket/Display.html?id=95544
+        https://rt.perl.org/rt3/Ticket/Display.html?id=95544
 
     Rewrite code so that we just override all subs for Perl >= 5.9.0 (when
     version.pm was added to the core).
@@ -336,7 +336,7 @@ This is not a complete list of changes.  See repository for full details:
 
   * Fix Makefile.PL to make Strawberry Perl happy.  Resolves:
 
-	https://rt.cpan.org/Public/Bug/Display.html?id=63991
+        https://rt.cpan.org/Public/Bug/Display.html?id=63991
 
 0.87 - 2010-12-09
 
@@ -398,12 +398,12 @@ This is not a complete list of changes.  See repository for full details:
     with Perl 5.8.1, v-strings are now magical and version.pm no longer has
     to guess.  Resolves:
 
-	    https://rt.cpan.org/Ticket/Display.html?id=50347
+        https://rt.cpan.org/Ticket/Display.html?id=50347
 
   * Also resolve the issue where attempting to install CPAN releases on top
     of core releases (e.g. 5.10.0 and 5.10.1) would not DTRT.  Resolves:
 
-	    https://rt.cpan.org/Ticket/Display.html?id=49667
+        https://rt.cpan.org/Ticket/Display.html?id=49667
 
 0.7702 - 2009-09-07
 
@@ -411,7 +411,7 @@ This is not a complete list of changes.  See repository for full details:
     something is a v-string or not for Perl 5.6.0 through 5.8.0 (inclusive).
     Resolves:
 
-	https://rt.cpan.org/Ticket/Display.html?id=49348
+        https://rt.cpan.org/Ticket/Display.html?id=49348
 
 0.7701 - 2009-07-28
 
@@ -420,7 +420,7 @@ This is not a complete list of changes.  See repository for full details:
     they contain a complete broken Test::More::use_ok which doesn't load the
     package into the correct namespace:
 
-	    https://rt.cpan.org/Ticket/Display.html?id=48268
+        https://rt.cpan.org/Ticket/Display.html?id=48268
 
     thus causing mysterious test failures.  No version.pm code was changed at
     all. :(

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -64,14 +64,14 @@ sub write_makefile
                      ( INSTALLDIRS => 'perl' ) :
                      ()
                    ),
-		   ( ($] < 5.012
-		       && ! $ENV{PERL_NO_HIGHLANDER}
-		       && ! ( $ENV{PERL_MM_OPT}
-			   && $ENV{PERL_MM_OPT} =~ /(?:INSTALL_BASE|PREFIX)/ )
-		       && ! grep { /INSTALL_BASE/ || /PREFIX/ } @ARGV ) ?
-		     ( UNINST => 1 ) :
-		     ()
-		   ),
+                   ( ($] < 5.012
+                      && ! $ENV{PERL_NO_HIGHLANDER}
+                      && ! ( $ENV{PERL_MM_OPT}
+                      && $ENV{PERL_MM_OPT} =~ /(?:INSTALL_BASE|PREFIX)/ )
+                      && ! grep { /INSTALL_BASE/ || /PREFIX/ } @ARGV ) ?
+                    ( UNINST => 1 ) :
+                    ()
+                   ),
                    PM              =>
                        {'lib/version.pm'  => '$(INST_LIBDIR)/version.pm',
                         'lib/version.pod' => '$(INST_LIBDIR)/version.pod',
@@ -83,10 +83,10 @@ sub write_makefile
                         },
                    PL_FILES        => {},
                    C               => [],
-		   ( $no_xs ?
-		       () :
-		       ( DIR       => ['vutil'])
-		   ),
+                   ( $no_xs ?
+                      () :
+                      ( DIR       => ['vutil'])
+                   ),
                    dist            => {
                        COMPRESS => 'gzip -9f',
                        SUFFIX => 'gz',

--- a/lib/version.pm
+++ b/lib/version.pm
@@ -17,44 +17,44 @@ our (@ISA, $STRICT, $LAX);
     local $SIG{'__DIE__'};
     eval "use version::vxs $VERSION";
     if ( $@ ) { # don't have the XS version installed
-	eval "use version::vpp $VERSION"; # don't tempt fate
-	die "$@" if ( $@ );
-	push @ISA, "version::vpp";
-	local $^W;
-	*version::qv = \&version::vpp::qv;
-	*version::declare = \&version::vpp::declare;
-	*version::_VERSION = \&version::vpp::_VERSION;
-	*version::vcmp = \&version::vpp::vcmp;
-	*version::new = \&version::vpp::new;
-	*version::numify = \&version::vpp::numify;
-	*version::normal = \&version::vpp::normal;
-	if ($] >= 5.009000) {
-	    no strict 'refs';
-	    *version::stringify = \&version::vpp::stringify;
-	    *{'version::(""'} = \&version::vpp::stringify;
-	    *{'version::(<=>'} = \&version::vpp::vcmp;
-	    *{'version::(cmp'} = \&version::vpp::vcmp;
-	    *version::parse = \&version::vpp::parse;
-	}
-    }
-    else { # use XS module
-	push @ISA, "version::vxs";
-	local $^W;
-	*version::declare = \&version::vxs::declare;
-	*version::qv = \&version::vxs::qv;
-	*version::_VERSION = \&version::vxs::_VERSION;
-	*version::vcmp = \&version::vxs::VCMP;
-	*version::new = \&version::vxs::new;
-	*version::numify = \&version::vxs::numify;
-	*version::normal = \&version::vxs::normal;
-	if ($] >= 5.009000) {
-	    no strict 'refs';
-	    *version::stringify = \&version::vxs::stringify;
-	    *{'version::(""'} = \&version::vxs::stringify;
-	    *{'version::(<=>'} = \&version::vxs::VCMP;
-	    *{'version::(cmp'} = \&version::vxs::VCMP;
-	    *version::parse = \&version::vxs::parse;
-	}
+        eval "use version::vpp $VERSION"; # don't tempt fate
+        die "$@" if ( $@ );
+        push @ISA, "version::vpp";
+        local $^W;
+        *version::qv = \&version::vpp::qv;
+        *version::declare = \&version::vpp::declare;
+        *version::_VERSION = \&version::vpp::_VERSION;
+        *version::vcmp = \&version::vpp::vcmp;
+        *version::new = \&version::vpp::new;
+        *version::numify = \&version::vpp::numify;
+        *version::normal = \&version::vpp::normal;
+        if ($] >= 5.009000) {
+            no strict 'refs';
+            *version::stringify = \&version::vpp::stringify;
+            *{'version::(""'} = \&version::vpp::stringify;
+            *{'version::(<=>'} = \&version::vpp::vcmp;
+            *{'version::(cmp'} = \&version::vpp::vcmp;
+            *version::parse = \&version::vpp::parse;
+        }
+        }
+        else { # use XS module
+        push @ISA, "version::vxs";
+        local $^W;
+        *version::declare = \&version::vxs::declare;
+        *version::qv = \&version::vxs::qv;
+        *version::_VERSION = \&version::vxs::_VERSION;
+        *version::vcmp = \&version::vxs::VCMP;
+        *version::new = \&version::vxs::new;
+        *version::numify = \&version::vxs::numify;
+        *version::normal = \&version::vxs::normal;
+        if ($] >= 5.009000) {
+            no strict 'refs';
+            *version::stringify = \&version::vxs::stringify;
+            *{'version::(""'} = \&version::vxs::stringify;
+            *{'version::(<=>'} = \&version::vxs::VCMP;
+            *{'version::(cmp'} = \&version::vxs::VCMP;
+            *version::parse = \&version::vxs::parse;
+        }
     }
 }
 
@@ -75,55 +75,55 @@ sub import {
 
     # Set up any derived class
     unless ($class eq $CLASS) {
-	local $^W;
-	*{$class.'::declare'} =  \&{$CLASS.'::declare'};
-	*{$class.'::qv'} = \&{$CLASS.'::qv'};
+        local $^W;
+        *{$class.'::declare'} =  \&{$CLASS.'::declare'};
+        *{$class.'::qv'} = \&{$CLASS.'::qv'};
     }
 
     my %args;
     if (@_) { # any remaining terms are arguments
-	map { $args{$_} = 1 } @_
+        map { $args{$_} = 1 } @_
     }
     else { # no parameters at all on use line
-	%args =
-	(
-	    qv => 1,
-	    'UNIVERSAL::VERSION' => 1,
-	);
+        %args =
+        (
+            qv => 1,
+            'UNIVERSAL::VERSION' => 1,
+        );
     }
 
     my $callpkg = caller();
 
     if (exists($args{declare})) {
-	*{$callpkg.'::declare'} =
-	    sub {return $class->declare(shift) }
-	  unless defined(&{$callpkg.'::declare'});
+        *{$callpkg.'::declare'} =
+            sub {return $class->declare(shift) }
+          unless defined(&{$callpkg.'::declare'});
     }
 
     if (exists($args{qv})) {
-	*{$callpkg.'::qv'} =
-	    sub {return $class->qv(shift) }
-	  unless defined(&{$callpkg.'::qv'});
+        *{$callpkg.'::qv'} =
+            sub {return $class->qv(shift) }
+          unless defined(&{$callpkg.'::qv'});
     }
 
     if (exists($args{'UNIVERSAL::VERSION'})) {
-	local $^W;
-	*UNIVERSAL::VERSION
-		= \&{$CLASS.'::_VERSION'};
+        local $^W;
+        *UNIVERSAL::VERSION
+            = \&{$CLASS.'::_VERSION'};
     }
 
     if (exists($args{'VERSION'})) {
-	*{$callpkg.'::VERSION'} = \&{$CLASS.'::_VERSION'};
+        *{$callpkg.'::VERSION'} = \&{$CLASS.'::_VERSION'};
     }
 
     if (exists($args{'is_strict'})) {
-	*{$callpkg.'::is_strict'} = \&{$CLASS.'::is_strict'}
-	  unless defined(&{$callpkg.'::is_strict'});
+        *{$callpkg.'::is_strict'} = \&{$CLASS.'::is_strict'}
+          unless defined(&{$callpkg.'::is_strict'});
     }
 
     if (exists($args{'is_lax'})) {
-	*{$callpkg.'::is_lax'} = \&{$CLASS.'::is_lax'}
-	  unless defined(&{$callpkg.'::is_lax'});
+        *{$callpkg.'::is_lax'} = \&{$CLASS.'::is_lax'}
+          unless defined(&{$callpkg.'::is_lax'});
     }
 }
 

--- a/lib/version/Internals.pod
+++ b/lib/version/Internals.pod
@@ -197,16 +197,16 @@ and do not contain either anchors or implicit groupings, so they can be
 included in your own regular expressions freely.  For example, consider
 the following code:
 
-	($pkg, $ver) =~ /
-		^[ \t]*
-		use [ \t]+($PKGNAME)
-		(?:[ \t]+($version::STRICT))?
-		[ \t]*;
-	/x;
+    ($pkg, $ver) =~ /
+        ^[ \t]*
+        use [ \t]+($PKGNAME)
+        (?:[ \t]+($version::STRICT))?
+        [ \t]*;
+    /x;
 
 This would match a line of the form:
 
-	use Foo::Bar::Baz v1.2.3;	# legal only in Perl 5.8.1+
+    use Foo::Bar::Baz v1.2.3;   # legal only in Perl 5.8.1+
 
 where C<$PKGNAME> is another regular expression that defines the legal
 forms for package names.
@@ -318,10 +318,10 @@ components:
       'alpha' => 1,
       'qv' => 1,
       'version' => [
-	1,
-	2,
-	3,
-	4
+        1,
+        2,
+        3,
+        4
       ]
     }, 'version' );
 

--- a/lib/version/regex.pm
+++ b/lib/version/regex.pm
@@ -80,8 +80,8 @@ our $STRICT =
 
 our $LAX_DECIMAL_VERSION =
     qr/ $LAX_INTEGER_PART (?: $FRACTION_PART | \. )? $LAX_ALPHA_PART?
-	|
-	$FRACTION_PART $LAX_ALPHA_PART?
+        |
+        $FRACTION_PART $LAX_ALPHA_PART?
     /x;
 
 # Lax dotted-decimal version number.  Distinguished by having either
@@ -92,9 +92,9 @@ our $LAX_DECIMAL_VERSION =
 
 our $LAX_DOTTED_DECIMAL_VERSION =
     qr/
-	v $LAX_INTEGER_PART (?: $LAX_DOTTED_DECIMAL_PART+ $LAX_ALPHA_PART? )?
-	|
-	$LAX_INTEGER_PART? $LAX_DOTTED_DECIMAL_PART{2,} $LAX_ALPHA_PART?
+        v $LAX_INTEGER_PART (?: $LAX_DOTTED_DECIMAL_PART+ $LAX_ALPHA_PART? )?
+        |
+        $LAX_INTEGER_PART? $LAX_DOTTED_DECIMAL_PART{2,} $LAX_ALPHA_PART?
     /x;
 
 # Complete lax version number syntax -- should generally be used
@@ -109,7 +109,7 @@ our $LAX =
 #--------------------------------------------------------------------------#
 
 # Preloaded methods go here.
-sub is_strict	{ defined $_[0] && $_[0] =~ qr/ \A $STRICT \z /x }
-sub is_lax	{ defined $_[0] && $_[0] =~ qr/ \A $LAX \z /x }
+sub is_strict { defined $_[0] && $_[0] =~ qr/ \A $STRICT \z /x }
+sub is_lax    { defined $_[0] && $_[0] =~ qr/ \A $LAX \z /x }
 
 1;

--- a/t/01base.t
+++ b/t/01base.t
@@ -39,17 +39,17 @@ ok defined($v), 'Fix for RT #47980';
 { # https://rt.cpan.org/Ticket/Display.html?id=81085
     eval { version::new() };
     like $@, qr'Usage: version::new\(class, version\)',
-	'No bus err when called as function';
+        'No bus err when called as function';
     eval { $x = 1; print version::new };
     like $@, qr'Usage: version::new\(class, version\)',
-	'No implicit object creation when called as function';
+        'No implicit object creation when called as function';
     eval { $x = "version"; print version::new };
     like $@, qr'Usage: version::new\(class, version\)',
-	'No implicit object creation when called as function';
+        'No implicit object creation when called as function';
 }
 
 {
     eval { version::vcmp($^V) };
     like $@, qr{Usage: version::\S+\(lobj, robj, \.\.\.\)},
-	'vcmp method throws error on single argument';
+        'vcmp method throws error on single argument';
 }

--- a/t/04strict_lax.t
+++ b/t/04strict_lax.t
@@ -9,7 +9,7 @@ use Test::More qw/no_plan/;
 # do strict lax tests in a sub to isolate a package to test importing
 SKIP: {
     skip 'No extended regexes Perl < 5.006', 174
-	if $] < 5.006_000;
+        if $] < 5.006_000;
     strict_lax_tests();
     is ref($version::LAX), 'Regexp', 'Can see $version::LAX '.$version::LAX ;
     is ref($version::STRICT), 'Regexp', 'Can see $version::STRICT '.$version::STRICT;
@@ -44,55 +44,55 @@ sub strict_lax_tests {
   # copied from perl core test t/op/packagev.t
   # format: STRING STRICT_OK LAX_OK
   my $strict_lax_data = << 'CASE_DATA';
-1.00		pass	pass
-1.00001		pass	pass
-0.123		pass	pass
-12.345		pass	pass
-42		pass	pass
-0		pass	pass
-0.0		pass	pass
-v1.2.3		pass	pass
-v1.2.3.4	pass	pass
-v0.1.2		pass	pass
-v0.0.0		pass	pass
-01		fail	pass
-01.0203		fail	pass
-v01		fail	pass
-v01.02.03	fail	pass
-.1		fail	pass
-.1.2		fail	pass
-1.		fail	pass
-1.a		fail	fail
-1._		fail	fail
-1.02_03		fail	pass
-v1.2_3		fail	pass
-v1.02_03	fail	pass
-v1.2_3_4	fail	fail
-v1.2_3.4	fail	fail
-1.2_3.4		fail	fail
-0_		fail	fail
-1_		fail	fail
-1_.		fail	fail
-1.1_		fail	fail
-1.02_03_04	fail	fail
-1.2.3		fail	pass
-v1.2		fail	pass
-v0		fail	pass
-v1		fail	pass
-v.1.2.3		fail	fail
-v		fail	fail
-v1.2345.6	fail	pass
-undef		fail	pass
-1a		fail	fail
-1.2a3		fail	fail
-bar		fail	fail
-_		fail	fail
+1.00        pass    pass
+1.00001     pass    pass
+0.123       pass    pass
+12.345      pass    pass
+42          pass    pass
+0           pass    pass
+0.0         pass    pass
+v1.2.3      pass    pass
+v1.2.3.4    pass    pass
+v0.1.2      pass    pass
+v0.0.0      pass    pass
+01          fail    pass
+01.0203     fail    pass
+v01         fail    pass
+v01.02.03   fail    pass
+.1          fail    pass
+.1.2        fail    pass
+1.          fail    pass
+1.a         fail    fail
+1._         fail    fail
+1.02_03     fail    pass
+v1.2_3      fail    pass
+v1.02_03    fail    pass
+v1.2_3_4    fail    fail
+v1.2_3.4    fail    fail
+1.2_3.4     fail    fail
+0_          fail    fail
+1_          fail    fail
+1_.         fail    fail
+1.1_        fail    fail
+1.02_03_04  fail    fail
+1.2.3       fail    pass
+v1.2        fail    pass
+v0          fail    pass
+v1          fail    pass
+v.1.2.3     fail    fail
+v           fail    fail
+v1.2345.6   fail    pass
+undef       fail    pass
+1a          fail    fail
+1.2a3       fail    fail
+bar         fail    fail
+_           fail    fail
 CASE_DATA
 
   require version;
   'version'->import( qw/is_strict is_lax/ );
   for my $case ( split qr/\n/, $strict_lax_data ) {
-    my ($v, $strict, $lax) = split qr/\t+/, $case;
+    my ($v, $strict, $lax) = split qr/\w+/, $case;
     main::ok( $strict eq 'pass' ? is_strict($v) : ! is_strict($v), "is_strict($v) [$strict]" );
     main::ok( $strict eq 'pass' ? version::is_strict($v) : ! version::is_strict($v), "version::is_strict($v) [$strict]" );
     main::ok( $lax eq 'pass' ? is_lax($v) : ! is_lax($v), "is_lax($v) [$lax]" );

--- a/t/05sigdie.t
+++ b/t/05sigdie.t
@@ -8,8 +8,8 @@ use Test::More tests => 1;
 
 BEGIN {
     $SIG{__DIE__}   = sub {
-	warn @_;
-	BAIL_OUT( q[Couldn't use module; can't continue.] );
+        warn @_;
+        BAIL_OUT( q[Couldn't use module; can't continue.] );
     };
 }
 

--- a/t/07locale.t
+++ b/t/07locale.t
@@ -15,52 +15,52 @@ BEGIN {
 }
 
 SKIP: {
-	skip 'No locale testing for Perl < 5.6.0', 7 if $] < 5.006;
-	skip 'No locale testing without d_setlocale', 7
-	    if(!$Config{d_setlocale});
+    skip 'No locale testing for Perl < 5.6.0', 7 if $] < 5.006;
+    skip 'No locale testing without d_setlocale', 7
+        if(!$Config{d_setlocale});
 
-	# test locale handling
-	my $warning = '';
+    # test locale handling
+    my $warning = '';
 
-	local $SIG{__WARN__} = sub { $warning = $_[0] };
+    local $SIG{__WARN__} = sub { $warning = $_[0] };
 
-	my $ver = 1.23;  # has to be floating point number
-	my $loc;
-	my $orig_loc = setlocale(LC_NUMERIC);
-	ok ($ver eq "1.23", 'Not using locale yet');  # Don't use is(),
-						      # because have to
-						      # evaluate in current
-						      # scope
-	use if $^O !~ /android/, 'locale';
+    my $ver = 1.23;  # has to be floating point number
+    my $loc;
+    my $orig_loc = setlocale(LC_NUMERIC);
+    ok ($ver eq "1.23", 'Not using locale yet');  # Don't use is(),
+                                                  # because have to
+                                                  # evaluate in current
+                                                  # scope
+    use if $^O !~ /android/, 'locale';
 
-	while (<DATA>) {
-	    chomp;
-	    $loc = setlocale( LC_ALL, $_);
-	    last if $loc && localeconv()->{decimal_point} eq ',';
-	}
-	skip 'Cannot test locale handling without a comma locale', 6
-	    unless $loc and localeconv()->{decimal_point} eq ',';
+    while (<DATA>) {
+        chomp;
+        $loc = setlocale( LC_ALL, $_);
+        last if $loc && localeconv()->{decimal_point} eq ',';
+    }
+    skip 'Cannot test locale handling without a comma locale', 6
+        unless $loc and localeconv()->{decimal_point} eq ',';
 
-	setlocale(LC_NUMERIC, $loc);
-	$ver = 1.23;  # has to be floating point number
-	ok ($ver eq "1,23", "Using locale: $loc");
-	$v = 'version'->new($ver);
-	unlike($warning, qr/Version string '1,23' contains invalid data/,
-	    "Process locale-dependent floating point");
-	ok ($v eq "1.23", "Locale doesn't apply to version objects");
-	ok ($v == $ver, "Comparison to locale floating point");
+    setlocale(LC_NUMERIC, $loc);
+    $ver = 1.23;  # has to be floating point number
+    ok ($ver eq "1,23", "Using locale: $loc");
+    $v = 'version'->new($ver);
+    unlike($warning, qr/Version string '1,23' contains invalid data/,
+        "Process locale-dependent floating point");
+    ok ($v eq "1.23", "Locale doesn't apply to version objects");
+    ok ($v == $ver, "Comparison to locale floating point");
 
-        TODO: { # Resolve https://rt.cpan.org/Ticket/Display.html?id=102272
-            local $TODO = 'Fails for Perl 5.x.0 < 5.19.0' if $] < 5.019000;
-            $ver = 'version'->new($]);
-            is "$ver", "$]", 'Use PV for dualvars';
-        }
-	setlocale( LC_ALL, $orig_loc); # reset this before possible skip
-	skip 'Cannot test RT#46921 with Perl < 5.008', 1
-	    if ($] < 5.008);
-	my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
-	(my $package = basename($filename)) =~ s/\.pm$//;
-	print $fh <<"EOF";
+    TODO: { # Resolve https://rt.cpan.org/Ticket/Display.html?id=102272
+        local $TODO = 'Fails for Perl 5.x.0 < 5.19.0' if $] < 5.019000;
+        $ver = 'version'->new($]);
+        is "$ver", "$]", 'Use PV for dualvars';
+    }
+    setlocale( LC_ALL, $orig_loc); # reset this before possible skip
+    skip 'Cannot test RT#46921 with Perl < 5.008', 1
+        if ($] < 5.008);
+    my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
+    (my $package = basename($filename)) =~ s/\.pm$//;
+    print $fh <<"EOF";
 package $package;
 use locale;
 use POSIX qw(locale_h);
@@ -72,11 +72,11 @@ eval "use Socket 1.7";
 setlocale( LC_ALL, '$orig_loc');
 1;
 EOF
-	close $fh;
+    close $fh;
 
-	eval "use lib '.'; use $package;";
-	unlike($warning, qr"Version string '1,7' contains invalid data",
-	    'Handle locale action-at-a-distance');
+    eval "use lib '.'; use $package;";
+    unlike($warning, qr"Version string '1,7' contains invalid data",
+        'Handle locale action-at-a-distance');
 }
 
 __DATA__

--- a/t/08_corelist.t
+++ b/t/08_corelist.t
@@ -11,7 +11,7 @@ use_ok("version", 0.9929);
 SKIP: {
     eval "use Module::CoreList 2.76";
     skip 'No tied hash in Modules::CoreList in Perl', 2
-	if $@;
+        if $@;
 
     my $foo = "version"->parse($Module::CoreList::version{5.008_000}{base});
 

--- a/t/09_list_util.t
+++ b/t/09_list_util.t
@@ -10,9 +10,9 @@ use Test::More;
 BEGIN {
     eval "use List::Util qw(reduce)";
     if ($@) {
-	plan skip_all => "No List::Util::reduce() available";
+        plan skip_all => "No List::Util::reduce() available";
     } else {
-	plan tests => 3;
+        plan tests => 3;
     }
 }
 
@@ -22,9 +22,9 @@ use List::Util qw(reduce);
 {
     my $fail = 0;
     my $ret = reduce {
-	version->parse($a);
-	$fail++ unless defined $a;
-	1
+        version->parse($a);
+        $fail++ unless defined $a;
+        1
     } "0.039", "0.035";
     is $fail, 0, 'reduce() with parse';
 }
@@ -32,9 +32,9 @@ use List::Util qw(reduce);
 {
     my $fail = 0;
     my $ret = reduce {
-	version->qv($a);
-	$fail++ unless defined $a;
-	1
+        version->qv($a);
+        $fail++ unless defined $a;
+        1
     } "0.039", "0.035";
     is $fail, 0, 'reduce() with qv';
 }

--- a/t/11_taint.t
+++ b/t/11_taint.t
@@ -5,9 +5,9 @@ use version;
 BEGIN {
     eval "use Test::Taint";
     if ($@) {
-	plan skip_all => "No Test::Taint available";
+        plan skip_all => "No Test::Taint available";
     } else {
-	plan tests => 6;
+        plan tests => 6;
     }
 }
 

--- a/t/coretests.pm
+++ b/t/coretests.pm
@@ -8,10 +8,10 @@ use File::Basename;
 if ($Test::More::VERSION < 0.48) { # Fix for RT#48268
     local $^W;
     *main::use_ok = sub ($;@) {
-	my ($pkg, $req, @args) = @_;
-	eval "use $pkg $req ".join(' ',@args);
-	is ${"$pkg\::VERSION"}, eval($req), 'Had to manually use version';
-	# If we made it this far, we are ok.
+        my ($pkg, $req, @args) = @_;
+        eval "use $pkg $req ".join(' ',@args);
+        is ${"$pkg\::VERSION"}, eval($req), 'Had to manually use version';
+        # If we made it this far, we are ok.
     };
 }
 
@@ -52,34 +52,34 @@ sub BaseTests {
     # test illegal formats
     eval {my $version = $CLASS->$method("1.2_3_4")};
     like($@, qr/multiple underscores/,
-	"Invalid version format (multiple underscores)");
+        "Invalid version format (multiple underscores)");
 
     eval {my $version = $CLASS->$method("1.2_3.4")};
     like($@, qr/underscores before decimal/,
-	"Invalid version format (underscores before decimal)");
+        "Invalid version format (underscores before decimal)");
 
     eval {my $version = $CLASS->$method("1_2")};
     like($@, qr/alpha without decimal/,
-	"Invalid version format (alpha without decimal)");
+        "Invalid version format (alpha without decimal)");
 
     eval { $version = $CLASS->$method("1.2b3")};
     like($@, qr/non-numeric data/,
-	"Invalid version format (non-numeric data)");
+        "Invalid version format (non-numeric data)");
 
     eval { $version = $CLASS->$method("-1.23")};
     like($@, qr/negative version number/,
-	"Invalid version format (negative version number)");
+        "Invalid version format (negative version number)");
 
     # from here on out capture the warning and test independently
     {
     eval{$version = $CLASS->$method("99 and 44/100 pure")};
 
     like($@, qr/non-numeric data/,
-	"Invalid version format (non-numeric data)");
+        "Invalid version format (non-numeric data)");
 
     eval{$version = $CLASS->$method("something")};
     like($@, qr/non-numeric data/,
-	"Invalid version format (non-numeric data)");
+        "Invalid version format (non-numeric data)");
 
     # reset the test object to something reasonable
     $version = $CLASS->$method("1.2.3");
@@ -122,7 +122,7 @@ sub BaseTests {
     $version = $CLASS->$method("2002.09.30.1");
     ok ( $version == "2002.9.30.1",'$version == 2002.9.30.1');
     ok ( $version->numify == 2002.009030001,
-	'$version->numify == 2002.009030001');
+        '$version->numify == 2002.009030001');
 
     # now test with alpha version form with string
     $version = $CLASS->$method("1.2.3");
@@ -180,20 +180,20 @@ sub BaseTests {
     ok ( !eval { $version*3 }, "noop *" );
     ok ( !eval { abs($version) }, "noop abs" );
 
-SKIP: {
-    skip "version require'd instead of use'd, cannot test $qv_declare", 3
-	unless defined $qv_declare;
-    # test the $qv_declare() sub
-    $version = $CLASS->$qv_declare("1.2");
-    is ( "$version", "v1.2", $qv_declare.'("1.2") == "1.2.0"' );
-    $version = $CLASS->$qv_declare(1.2);
-    is ( "$version", "v1.2", $qv_declare.'(1.2) == "1.2.0"' );
-    isa_ok( $CLASS->$qv_declare('5.008'), $CLASS );
-}
+    SKIP: {
+        skip "version require'd instead of use'd, cannot test $qv_declare", 3
+            unless defined $qv_declare;
+        # test the $qv_declare() sub
+        $version = $CLASS->$qv_declare("1.2");
+        is ( "$version", "v1.2", $qv_declare.'("1.2") == "1.2.0"' );
+        $version = $CLASS->$qv_declare(1.2);
+        is ( "$version", "v1.2", $qv_declare.'(1.2) == "1.2.0"' );
+        isa_ok( $CLASS->$qv_declare('5.008'), $CLASS );
+    }
 
     # test creation from existing version object
     ok (eval {$new_version = $CLASS->$method($version)},
-	    "new from existing object");
+        "new from existing object");
     ok ($new_version == $version, "class->$method($version) identical");
     $new_version = $version->$method(0);
     isa_ok ($new_version, $CLASS );
@@ -216,140 +216,140 @@ SKIP: {
     # test reformed UNIVERSAL::VERSION
 
     my $error_regex = $] < 5.006
-	? 'version \d required'
-	: 'does not define \$t.{7}::VERSION';
+        ? 'version \d required'
+        : 'does not define \$t.{7}::VERSION';
 
     {
-	my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
-	(my $package = basename($filename)) =~ s/\.pm$//;
-	print $fh "package $package;\n\$$package\::VERSION=0.58;\n1;\n";
-	close $fh;
+        my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
+        (my $package = basename($filename)) =~ s/\.pm$//;
+        print $fh "package $package;\n\$$package\::VERSION=0.58;\n1;\n";
+        close $fh;
 
-	$version = 0.58;
-	eval "use lib '.'; use $package $version";
-	unlike($@, qr/$package version $version/,
-		'Replacement eval works with exact version');
+        $version = 0.58;
+        eval "use lib '.'; use $package $version";
+        unlike($@, qr/$package version $version/,
+            'Replacement eval works with exact version');
 
-	# test as class method
-	$new_version = $package->VERSION;
-	cmp_ok($new_version,'==',$version, "Called as class method");
+        # test as class method
+        $new_version = $package->VERSION;
+        cmp_ok($new_version,'==',$version, "Called as class method");
 
-	eval "print Completely::Unknown::Module->VERSION";
-	if ( $] < 5.008 ) {
-	    unlike($@, qr/$error_regex/,
-		"Don't freak if the module doesn't even exist");
-	}
-	else {
-	    unlike($@, qr/defines neither package nor VERSION/,
-		"Don't freak if the module doesn't even exist");
-	}
+        eval "print Completely::Unknown::Module->VERSION";
+        if ( $] < 5.008 ) {
+            unlike($@, qr/$error_regex/,
+                "Don't freak if the module doesn't even exist");
+        }
+        else {
+            unlike($@, qr/defines neither package nor VERSION/,
+                "Don't freak if the module doesn't even exist");
+        }
 
-	# this should fail even with old UNIVERSAL::VERSION
-	$version += 0.01;
-	eval "use lib '.'; use $package $version";
-	like($@, qr/$package version $version/,
-		'Replacement eval works with incremented version');
+        # this should fail even with old UNIVERSAL::VERSION
+        $version += 0.01;
+        eval "use lib '.'; use $package $version";
+        like($@, qr/$package version $version/,
+            'Replacement eval works with incremented version');
 
-	$version =~ s/0+$//; #convert to string and remove trailing 0's
-	chop($version);	# shorten by 1 digit, should still succeed
-	eval "use lib '.'; use $package $version";
-	unlike($@, qr/$package version $version/,
-		'Replacement eval works with single digit');
+        $version =~ s/0+$//;    # convert to string and remove trailing 0's
+        chop($version);         # shorten by 1 digit, should still succeed
+        eval "use lib '.'; use $package $version";
+        unlike($@, qr/$package version $version/,
+            'Replacement eval works with single digit');
 
-	# this would fail with old UNIVERSAL::VERSION
-	$version += 0.1;
-	eval "use lib '.'; use $package $version";
-	like($@, qr/$package version $version/,
-		'Replacement eval works with incremented digit');
-	unlink $filename;
+        # this would fail with old UNIVERSAL::VERSION
+        $version += 0.1;
+        eval "use lib '.'; use $package $version";
+        like($@, qr/$package version $version/,
+            'Replacement eval works with incremented digit');
+        unlink $filename;
     }
 
     { # dummy up some variously broken modules for testing
-	my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
-	(my $package = basename($filename)) =~ s/\.pm$//;
-	print $fh "1;\n";
-	close $fh;
+        my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
+        (my $package = basename($filename)) =~ s/\.pm$//;
+        print $fh "1;\n";
+        close $fh;
 
-	eval "use lib '.'; use $package 3;";
-	if ( $] < 5.008 ) {
-	    like($@, qr/$error_regex/,
-		'Replacement handles modules without package or VERSION');
-	}
-	else {
-	    like($@, qr/defines neither package nor VERSION/,
-		'Replacement handles modules without package or VERSION');
-	}
-	eval "use lib '.'; use $package; \$version = $package->VERSION";
-	unlike ($@, qr/$error_regex/,
-	    'Replacement handles modules without package or VERSION');
-	ok (!defined($version), "Called as class method");
-	unlink $filename;
+        eval "use lib '.'; use $package 3;";
+        if ( $] < 5.008 ) {
+            like($@, qr/$error_regex/,
+                'Replacement handles modules without package or VERSION');
+        }
+        else {
+            like($@, qr/defines neither package nor VERSION/,
+                'Replacement handles modules without package or VERSION');
+        }
+        eval "use lib '.'; use $package; \$version = $package->VERSION";
+        unlike ($@, qr/$error_regex/,
+            'Replacement handles modules without package or VERSION');
+        ok (!defined($version), "Called as class method");
+        unlink $filename;
     }
 
     { # dummy up some variously broken modules for testing
-	my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
-	(my $package = basename($filename)) =~ s/\.pm$//;
-	print $fh "package $package;\n#look ma no VERSION\n1;\n";
-	close $fh;
-	eval "use lib '.'; use $package 3;";
-	like ($@, qr/$error_regex/,
-	    'Replacement handles modules without VERSION');
-	eval "use lib '.'; use $package; print $package->VERSION";
-	unlike ($@, qr/$error_regex/,
-	    'Replacement handles modules without VERSION');
-	unlink $filename;
+        my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
+        (my $package = basename($filename)) =~ s/\.pm$//;
+        print $fh "package $package;\n#look ma no VERSION\n1;\n";
+        close $fh;
+        eval "use lib '.'; use $package 3;";
+        like ($@, qr/$error_regex/,
+            'Replacement handles modules without VERSION');
+        eval "use lib '.'; use $package; print $package->VERSION";
+        unlike ($@, qr/$error_regex/,
+            'Replacement handles modules without VERSION');
+        unlink $filename;
     }
 
     { # dummy up some variously broken modules for testing
-	my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
-	(my $package = basename($filename)) =~ s/\.pm$//;
-	print $fh "package $package;\n\@VERSION = ();\n1;\n";
-	close $fh;
-	eval "use lib '.'; use $package 3;";
-	like ($@, qr/$error_regex/,
-	    'Replacement handles modules without VERSION');
-	eval "use lib '.'; use $package; print $package->VERSION";
-	unlike ($@, qr/$error_regex/,
-	    'Replacement handles modules without VERSION');
-	unlink $filename;
+        my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
+        (my $package = basename($filename)) =~ s/\.pm$//;
+        print $fh "package $package;\n\@VERSION = ();\n1;\n";
+        close $fh;
+        eval "use lib '.'; use $package 3;";
+        like ($@, qr/$error_regex/,
+            'Replacement handles modules without VERSION');
+        eval "use lib '.'; use $package; print $package->VERSION";
+        unlike ($@, qr/$error_regex/,
+            'Replacement handles modules without VERSION');
+        unlink $filename;
     }
-SKIP:    { # https://rt.perl.org/rt3/Ticket/Display.html?id=95544
-	skip "version require'd instead of use'd, cannot test UNIVERSAL::VERSION", 2
-	    unless defined $qv_declare;
-	my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
-	(my $package = basename($filename)) =~ s/\.pm$//;
-	print $fh "package $package;\n\$VERSION = '3alpha';\n1;\n";
-	close $fh;
-	eval "use lib '.'; use $package; print $package->VERSION";
-	like ($@, qr/Invalid version format \(non-numeric data\)/,
-	    'Warn about bad \$VERSION');
-	eval "use lib '.'; use $package 1;";
-	like ($@, qr/Invalid version format \(non-numeric data\)/,
-	    'Warn about bad $VERSION');
-    }
-
-SKIP: 	{
-	skip 'Cannot test bare v-strings with Perl < 5.6.0', 4
-		if $] < 5.006_000;
-	$version = $CLASS->$method(1.2.3);
-	ok("$version" eq "v1.2.3", '"$version" eq 1.2.3');
-	$version = $CLASS->$method(1.0.0);
-	$new_version = $CLASS->$method(1);
-	ok($version == $new_version, '$version == $new_version');
-	skip "version require'd instead of use'd, cannot test declare", 1
-	    unless defined $qv_declare;
-	$version = &$qv_declare(1.2.3);
-	ok("$version" eq "v1.2.3", 'v-string initialized $qv_declare()');
+    SKIP: { # https://rt.perl.org/rt3/Ticket/Display.html?id=95544
+        skip "version require'd instead of use'd, cannot test UNIVERSAL::VERSION", 2
+            unless defined $qv_declare;
+        my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
+        (my $package = basename($filename)) =~ s/\.pm$//;
+        print $fh "package $package;\n\$VERSION = '3alpha';\n1;\n";
+        close $fh;
+        eval "use lib '.'; use $package; print $package->VERSION";
+        like ($@, qr/Invalid version format \(non-numeric data\)/,
+            'Warn about bad \$VERSION');
+        eval "use lib '.'; use $package 1;";
+        like ($@, qr/Invalid version format \(non-numeric data\)/,
+            'Warn about bad $VERSION');
     }
 
-SKIP: 	{
-	skip 'Cannot test bare alpha v-strings with Perl < 5.8.1', 2
-		if $] lt 5.008_001;
-	$version = $CLASS->$method(v1.2.3_4);
-	$DB::single = 1;
-	is($version, "v1.2.34", '"$version" eq "v1.2.34"');
-	$version = $CLASS->$method(eval "v1.2.3_4");
-	is($version, "v1.2.34", '"$version" eq "v1.2.34" (from eval)');
+    SKIP: {
+        skip 'Cannot test bare v-strings with Perl < 5.6.0', 4
+            if $] < 5.006_000;
+        $version = $CLASS->$method(1.2.3);
+        ok("$version" eq "v1.2.3", '"$version" eq 1.2.3');
+        $version = $CLASS->$method(1.0.0);
+        $new_version = $CLASS->$method(1);
+        ok($version == $new_version, '$version == $new_version');
+        skip "version require'd instead of use'd, cannot test declare", 1
+            unless defined $qv_declare;
+        $version = &$qv_declare(1.2.3);
+        ok("$version" eq "v1.2.3", 'v-string initialized $qv_declare()');
+    }
+
+    SKIP: {
+        skip 'Cannot test bare alpha v-strings with Perl < 5.8.1', 2
+            if $] lt 5.008_001;
+        $version = $CLASS->$method(v1.2.3_4);
+        $DB::single = 1;
+        is($version, "v1.2.34", '"$version" eq "v1.2.34"');
+        $version = $CLASS->$method(eval "v1.2.3_4");
+        is($version, "v1.2.34", '"$version" eq "v1.2.34" (from eval)');
     }
 
     # trailing zero testing (reported by Andreas Koenig).
@@ -375,11 +375,11 @@ SKIP: 	{
     ok("$version" ne undef, "Undef version comparison #2");
     $version = $CLASS->$method('undef');
     unlike($warning, qr/^Version string 'undef' contains invalid data/,
-	"Version string 'undef'");
+        "Version string 'undef'");
 
     $version = $CLASS->$method(undef);
     like($warning, qr/^Use of uninitialized value/,
-	"Version string 'undef'");
+        "Version string 'undef'");
     ok($version == 'undef', "Undef version comparison #3");
     ok($version ==  undef,  "Undef version comparison #4");
     eval "\$version = \$CLASS->$method()"; # no parameter at all
@@ -389,249 +389,249 @@ SKIP: 	{
 
     $version = $CLASS->$method(0.000001);
     unlike($warning, qr/^Version string '1e-06' contains invalid data/,
-	"Very small version objects");
+        "Very small version objects");
     }
 
-SKIP: {
-	my $warning;
-	local $SIG{__WARN__} = sub { $warning = $_[0] };
-	# dummy up a legal module for testing RT#19017
-	my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
-	(my $package = basename($filename)) =~ s/\.pm$//;
-	print $fh <<"EOF";
+    SKIP: {
+        my $warning;
+        local $SIG{__WARN__} = sub { $warning = $_[0] };
+        # dummy up a legal module for testing RT#19017
+        my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
+        (my $package = basename($filename)) =~ s/\.pm$//;
+        print $fh <<"EOF";
 package $package;
 use $CLASS; \$VERSION = ${CLASS}->new('0.0.4');
 1;
 EOF
-	close $fh;
+        close $fh;
 
-	eval "use lib '.'; use $package 0.000008;";
-	like ($@, qr/^$package version 0.000008 required/,
-	    "Make sure very small versions don't freak");
-	eval "use lib '.'; use $package 1;";
-	like ($@, qr/^$package version 1 required/,
-	    "Comparing vs. version with no decimal");
-	eval "use lib '.'; use $package 1.;";
-	like ($@, qr/^$package version 1 required/,
-	    "Comparing vs. version with decimal only");
-	if ( $] < 5.006_000 ) {
-	    skip 'Cannot "use" extended versions with Perl < 5.6.0', 3;
-	}
-	eval "use lib '.'; use $package v0.0.8;";
-	my $regex = "^$package version v0.0.8 required";
-	like ($@, qr/$regex/, "Make sure very small versions don't freak");
+        eval "use lib '.'; use $package 0.000008;";
+        like ($@, qr/^$package version 0.000008 required/,
+            "Make sure very small versions don't freak");
+        eval "use lib '.'; use $package 1;";
+        like ($@, qr/^$package version 1 required/,
+            "Comparing vs. version with no decimal");
+        eval "use lib '.'; use $package 1.;";
+        like ($@, qr/^$package version 1 required/,
+            "Comparing vs. version with decimal only");
+        if ( $] < 5.006_000 ) {
+            skip 'Cannot "use" extended versions with Perl < 5.6.0', 3;
+        }
+        eval "use lib '.'; use $package v0.0.8;";
+        my $regex = "^$package version v0.0.8 required";
+        like ($@, qr/$regex/, "Make sure very small versions don't freak");
 
-	$regex =~ s/8/4/; # set for second test
-	eval "use lib '.'; use $package v0.0.4;";
-	unlike($@, qr/$regex/, 'Succeed - required == VERSION');
-	cmp_ok ( $package->VERSION, 'eq', '0.0.4', 'No undef warnings' );
-	unlink $filename;
+        $regex =~ s/8/4/; # set for second test
+        eval "use lib '.'; use $package v0.0.4;";
+        unlike($@, qr/$regex/, 'Succeed - required == VERSION');
+        cmp_ok ( $package->VERSION, 'eq', '0.0.4', 'No undef warnings' );
+        unlink $filename;
     }
 
-SKIP: {
-    skip "Cannot test \"use parent $CLASS\"  when require is used", 3
-	unless defined $qv_declare;
-    my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
-    (my $package = basename($filename)) =~ s/\.pm$//;
-    print $fh <<"EOF";
+    SKIP: {
+        skip "Cannot test \"use parent $CLASS\"  when require is used", 3
+            unless defined $qv_declare;
+        my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
+        (my $package = basename($filename)) =~ s/\.pm$//;
+        print $fh <<"EOF";
 package $package;
 use base $CLASS;
 1;
 EOF
-    close $fh;
-    # need to eliminate any other $qv_declare()'s
-    undef *{"main\::$qv_declare"};
-    ok(!defined(&{"main\::$qv_declare"}), "make sure we cleared $qv_declare() properly");
-    eval "use lib '.'; use $package qw/declare qv/;";
-    ok(defined(&{"main\::$qv_declare"}), "make sure we exported $qv_declare() properly");
-    isa_ok( &$qv_declare(1.2), $package);
-    unlink $filename;
-}
+        close $fh;
+        # need to eliminate any other $qv_declare()'s
+        undef *{"main\::$qv_declare"};
+        ok(!defined(&{"main\::$qv_declare"}), "make sure we cleared $qv_declare() properly");
+        eval "use lib '.'; use $package qw/declare qv/;";
+        ok(defined(&{"main\::$qv_declare"}), "make sure we exported $qv_declare() properly");
+        isa_ok( &$qv_declare(1.2), $package);
+        unlink $filename;
+    }
 
-SKIP: {
-	if ( $] < 5.006_000 ) {
-	    skip 'Cannot "use" extended versions with Perl < 5.6.0', 3;
-	}
-	my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
-	(my $package = basename($filename)) =~ s/\.pm$//;
-	print $fh <<"EOF";
+    SKIP: {
+        if ( $] < 5.006_000 ) {
+            skip 'Cannot "use" extended versions with Perl < 5.6.0', 3;
+        }
+        my ($fh, $filename) = tempfile('tXXXXXXX', SUFFIX => '.pm', UNLINK => 1);
+        (my $package = basename($filename)) =~ s/\.pm$//;
+        print $fh <<"EOF";
 package $package;
 \$VERSION = 1.0;
 1;
 EOF
-	close $fh;
-	eval "use lib '.'; use $package 1.001;";
-	like ($@, qr/^$package version 1.001 required/,
-	    "User typed numeric so we error with numeric");
-	eval "use lib '.'; use $package v1.1.0;";
-	like ($@, qr/^$package version v1.1.0 required/,
-	    "User typed extended so we error with extended");
-	unlink $filename;
+        close $fh;
+        eval "use lib '.'; use $package 1.001;";
+        like ($@, qr/^$package version 1.001 required/,
+            "User typed numeric so we error with numeric");
+        eval "use lib '.'; use $package v1.1.0;";
+        like ($@, qr/^$package version v1.1.0 required/,
+            "User typed extended so we error with extended");
+        unlink $filename;
     }
 
     eval 'my $v = $CLASS->$method("1._1");';
     unlike($@, qr/^Invalid version format \(alpha with zero width\)/,
-	"Invalid version format 1._1");
+        "Invalid version format 1._1");
 
     {
-	my $warning;
-	local $SIG{__WARN__} = sub { $warning = $_[0] };
-	eval 'my $v = $CLASS->$method(~0);';
-	unlike($@, qr/Integer overflow in version/, "Too large version");
-	like($warning, qr/Integer overflow in version/, "Too large version");
+        my $warning;
+        local $SIG{__WARN__} = sub { $warning = $_[0] };
+        eval 'my $v = $CLASS->$method(~0);';
+        unlike($@, qr/Integer overflow in version/, "Too large version");
+        like($warning, qr/Integer overflow in version/, "Too large version");
     }
 
     {
         local $Data::Dumper::Sortkeys= 1;
-	# http://rt.cpan.org/Public/Bug/Display.html?id=30004
-	my $v1 = $CLASS->$method("v0.1_1");
-	(my $alpha1 = Dumper($v1)) =~ s/.+'alpha' => ([^,]+),.+/$1/ms;
-	my $v2 = $CLASS->$method($v1);
-	(my $alpha2 = Dumper($v2)) =~ s/.+'alpha' => ([^,]+),.+/$1/ms;
-	is $alpha2, $alpha1, "Don't fall for Data::Dumper's tricks";
+        # http://rt.cpan.org/Public/Bug/Display.html?id=30004
+        my $v1 = $CLASS->$method("v0.1_1");
+        (my $alpha1 = Dumper($v1)) =~ s/.+'alpha' => ([^,]+),.+/$1/ms;
+        my $v2 = $CLASS->$method($v1);
+        (my $alpha2 = Dumper($v2)) =~ s/.+'alpha' => ([^,]+),.+/$1/ms;
+        is $alpha2, $alpha1, "Don't fall for Data::Dumper's tricks";
     }
 
     {
-	# http://rt.perl.org/rt3/Ticket/Display.html?id=56606
-	my $badv = bless { version => [1,2,3] }, $CLASS;
-	is $badv, '1.002003', "Deal with badly serialized versions from YAML";
-	my $badv2 = bless { qv => 1, version => [1,2,3] }, $CLASS;
-	is $badv2, 'v1.2.3', "Deal with badly serialized versions from YAML ";
+        # http://rt.perl.org/rt3/Ticket/Display.html?id=56606
+        my $badv = bless { version => [1,2,3] }, $CLASS;
+        is $badv, '1.002003', "Deal with badly serialized versions from YAML";
+        my $badv2 = bless { qv => 1, version => [1,2,3] }, $CLASS;
+        is $badv2, 'v1.2.3', "Deal with badly serialized versions from YAML ";
     }
 
     {
-	# https://rt.cpan.org/Public/Bug/Display.html?id=70950
-	# test indirect usage of version objects
-	my $sum = 0;
-	eval '$sum += $CLASS->$method("v2.0.0")';
-	like $@, qr/operation not supported with version object/,
-	    'No math operations with version objects';
-	# test direct usage of version objects
-	my $v = $CLASS->$method("v2.0.0");
-	eval '$v += 1';
-	like $@, qr/operation not supported with version object/,
-	    'No math operations with version objects';
+        # https://rt.cpan.org/Public/Bug/Display.html?id=70950
+        # test indirect usage of version objects
+        my $sum = 0;
+        eval '$sum += $CLASS->$method("v2.0.0")';
+        like $@, qr/operation not supported with version object/,
+            'No math operations with version objects';
+        # test direct usage of version objects
+        my $v = $CLASS->$method("v2.0.0");
+        eval '$v += 1';
+        like $@, qr/operation not supported with version object/,
+            'No math operations with version objects';
     }
 
     {
-	# https://rt.cpan.org/Ticket/Display.html?id=72365
-	# https://rt.perl.org/rt3/Ticket/Display.html?id=102586
-    	# https://rt.cpan.org/Ticket/Display.html?id=78328
-	eval 'my $v = $CLASS->$method("version")';
-	like $@, qr/Invalid version format/,
-	    "The string 'version' is not a version for $method";
-	eval 'my $v = $CLASS->$method("ver510n")';
-	like $@, qr/Invalid version format/,
-	    'All strings starting with "v" are not versions';
+        # https://rt.cpan.org/Ticket/Display.html?id=72365
+        # https://rt.perl.org/rt3/Ticket/Display.html?id=102586
+        # https://rt.cpan.org/Ticket/Display.html?id=78328
+        eval 'my $v = $CLASS->$method("version")';
+        like $@, qr/Invalid version format/,
+            "The string 'version' is not a version for $method";
+        eval 'my $v = $CLASS->$method("ver510n")';
+        like $@, qr/Invalid version format/,
+            'All strings starting with "v" are not versions';
     }
 
-SKIP: {
-	if ( $] < 5.006_000 ) {
-	    skip 'No v-string support at all < 5.6.0', 2;
-	}
-	# https://rt.cpan.org/Ticket/Display.html?id=49348
-	my $v = $CLASS->$method("420");
-	is "$v", "420", 'Correctly guesses this is not a v-string';
-	$v = $CLASS->$method(4.2.0);
-	is "$v", 'v4.2.0', 'Correctly guess that this is a v-string';
+    SKIP: {
+        if ( $] < 5.006_000 ) {
+            skip 'No v-string support at all < 5.6.0', 2;
+        }
+        # https://rt.cpan.org/Ticket/Display.html?id=49348
+        my $v = $CLASS->$method("420");
+        is "$v", "420", 'Correctly guesses this is not a v-string';
+        $v = $CLASS->$method(4.2.0);
+        is "$v", 'v4.2.0', 'Correctly guess that this is a v-string';
     }
-SKIP: {
-	if ( $] < 5.006_000 ) {
-	    skip 'No v-string support at all < 5.6.0', 4;
-	}
-	# https://rt.cpan.org/Ticket/Display.html?id=50347
-	# Check that the qv() implementation does not change
+    SKIP: {
+        if ( $] < 5.006_000 ) {
+            skip 'No v-string support at all < 5.6.0', 4;
+        }
+        # https://rt.cpan.org/Ticket/Display.html?id=50347
+        # Check that the qv() implementation does not change
 
-	ok $CLASS->$method(1.2.3) < $CLASS->$method(1.2.3.1), 'Compare 3 and 4 digit v-strings' ;
-	ok $CLASS->$method(v1.2.3) < $CLASS->$method(v1.2.3.1), 'Compare 3 and 4 digit v-strings, leaving v';
-	ok $CLASS->$method("1.2.3") < $CLASS->$method("1.2.3.1"), 'Compare 3 and 4 digit v-strings, quoted';
-	ok $CLASS->$method("v1.2.3") < $CLASS->$method("v1.2.3.1"), 'Compare 3 and 4 digit v-strings, quoted leading v';
+        ok $CLASS->$method(1.2.3) < $CLASS->$method(1.2.3.1), 'Compare 3 and 4 digit v-strings' ;
+        ok $CLASS->$method(v1.2.3) < $CLASS->$method(v1.2.3.1), 'Compare 3 and 4 digit v-strings, leaving v';
+        ok $CLASS->$method("1.2.3") < $CLASS->$method("1.2.3.1"), 'Compare 3 and 4 digit v-strings, quoted';
+        ok $CLASS->$method("v1.2.3") < $CLASS->$method("v1.2.3.1"), 'Compare 3 and 4 digit v-strings, quoted leading v';
     }
 
     {
-	eval '$CLASS->$method("version")';
-	pass("no crash with ${CLASS}->${method}('version')");
-	{
-	    package _102586;
-	    sub TIESCALAR { bless [] }
-	    sub FETCH { "version" }
-	    sub STORE { }
-	    my $v;
-	    tie $v, __PACKAGE__;
-	    $v = $CLASS->$method(1);
-	    eval '$CLASS->$method($v)';
-	}
-	pass('no crash with version->new($tied) where $tied returns "version"');
+        eval '$CLASS->$method("version")';
+        pass("no crash with ${CLASS}->${method}('version')");
+        {
+            package _102586;
+            sub TIESCALAR { bless [] }
+            sub FETCH { "version" }
+            sub STORE { }
+            my $v;
+            tie $v, __PACKAGE__;
+            $v = $CLASS->$method(1);
+            eval '$CLASS->$method($v)';
+        }
+        pass('no crash with version->new($tied) where $tied returns "version"');
     }
 
     { # [perl #112478]
-	$_112478::VERSION = 9e99;
-	ok eval { _112478->VERSION(9e99); 1 }, '->VERSION(9e99) succeeds'
-	    or diag $@;
-	$_112478::VERSION = 1;
-	eval { _112478->VERSION(9e99) };
-	unlike $@, qr/panic/, '->VERSION(9e99) does not panic';
+        $_112478::VERSION = 9e99;
+        ok eval { _112478->VERSION(9e99); 1 }, '->VERSION(9e99) succeeds'
+            or diag $@;
+        $_112478::VERSION = 1;
+        eval { _112478->VERSION(9e99) };
+        unlike $@, qr/panic/, '->VERSION(9e99) does not panic';
     }
 
     { # https://rt.cpan.org/Ticket/Display.html?id=79259
-	my $v = $CLASS->new("0.52_0");
-	ok $v->is_alpha, 'Just checking';
-	is $v->numify, '0.520', 'Correctly nummified';
+        my $v = $CLASS->new("0.52_0");
+        ok $v->is_alpha, 'Just checking';
+        is $v->numify, '0.520', 'Correctly nummified';
     }
 
     { # https://rt.cpan.org/Ticket/Display.html?id=88495
-	@ver::ISA = $CLASS;
-	is ref('ver'->new), 'ver', 'ver can inherit from version';
-	is ref('ver'->qv("1.2.3")), 'ver', 'ver can inherit from version';
+        @ver::ISA = $CLASS;
+        is ref('ver'->new), 'ver', 'ver can inherit from version';
+        is ref('ver'->qv("1.2.3")), 'ver', 'ver can inherit from version';
     }
 
     { # discovered while integrating with bleadperl
-	eval {my $v = $CLASS->new([1,2,3]) };
-	like $@, qr/Invalid version format/, 'Do not crash for garbage';
-	eval {my $v = $CLASS->new({1 => 2}) };
-	like $@, qr/Invalid version format/, 'Do not crash for garbage';
+        eval {my $v = $CLASS->new([1,2,3]) };
+        like $@, qr/Invalid version format/, 'Do not crash for garbage';
+        eval {my $v = $CLASS->new({1 => 2}) };
+        like $@, qr/Invalid version format/, 'Do not crash for garbage';
     }
     { # https://rt.cpan.org/Ticket/Display.html?id=93603
-	eval {my $v = $CLASS->$method('.1.')};
-	like $@, qr/trailing decimal/, 'Forbid trailing decimals';
-	eval {my $v = $CLASS->$method('.1.2.')};
-	like $@, qr/trailing decimal/, 'Forbid trailing decimals';
+        eval {my $v = $CLASS->$method('.1.')};
+        like $@, qr/trailing decimal/, 'Forbid trailing decimals';
+        eval {my $v = $CLASS->$method('.1.2.')};
+        like $@, qr/trailing decimal/, 'Forbid trailing decimals';
     }
     { # https://rt.cpan.org/Ticket/Display.html?id=93715
-	eval {my $v = $CLASS->new(v1.2)};
-	unlike $@, qr/non-numeric data/, 'Handle short v-strings';
-	eval {my $v = $CLASS->new(v1)};
-	unlike $@, qr/non-numeric data/, 'Handle short v-strings';
+        eval {my $v = $CLASS->new(v1.2)};
+        unlike $@, qr/non-numeric data/, 'Handle short v-strings';
+        eval {my $v = $CLASS->new(v1)};
+        unlike $@, qr/non-numeric data/, 'Handle short v-strings';
     }
     {
-	my $two31 = '2147483648';
-	my $v = $CLASS->new($two31);
-	is "$v", 'v.Inf', 'Element Exceeds VERSION_MAX';
-	like $warning, qr/Integer overflow in version/, 'Overflow warning';
-	$v = $CLASS->new("1.$two31.$two31");
-	is "$v", 'v.Inf', 'Element Exceeds VERSION_MAX';
-	like $warning, qr/Integer overflow in version/, 'Overflow warning';
+        my $two31 = '2147483648';
+        my $v = $CLASS->new($two31);
+        is "$v", 'v.Inf', 'Element Exceeds VERSION_MAX';
+        like $warning, qr/Integer overflow in version/, 'Overflow warning';
+        $v = $CLASS->new("1.$two31.$two31");
+        is "$v", 'v.Inf', 'Element Exceeds VERSION_MAX';
+        like $warning, qr/Integer overflow in version/, 'Overflow warning';
     }
     {
-	# now as a number
-	$two31 = 2**31;
-	$v = $CLASS->new($two31);
-	is "$v", 'v.Inf', 'Element Exceeds VERSION_MAX';
-	like $warning, qr/Integer overflow in version/, 'Overflow warning';
+        # now as a number
+        $two31 = 2**31;
+        $v = $CLASS->new($two31);
+        is "$v", 'v.Inf', 'Element Exceeds VERSION_MAX';
+        like $warning, qr/Integer overflow in version/, 'Overflow warning';
     }
     { # https://rt.cpan.org/Ticket/Display.html?id=101628
-	undef $warning;
-	$v = $CLASS->new('1.1.00000000010');
-	is $v->normal, "v1.1.10", 'Ignore leading zeros';
-	unlike $warning, qr/Integer overflow in version/, 'No overflow warning';
+        undef $warning;
+        $v = $CLASS->new('1.1.00000000010');
+        is $v->normal, "v1.1.10", 'Ignore leading zeros';
+        unlike $warning, qr/Integer overflow in version/, 'No overflow warning';
     }
     { # https://rt.cpan.org/Ticket/Display.html?id=93340
-	$v = $CLASS->parse(q[2.6_01]);
-	is $v->normal, 'v2.601.0', 'Normal strips underscores from alphas'
+        $v = $CLASS->parse(q[2.6_01]);
+        is $v->normal, 'v2.601.0', 'Normal strips underscores from alphas'
     }
     { # https://rt.cpan.org/Ticket/Display.html?id=98744
-	$v = $CLASS->new("1.02_003");
-	is $v->numify, '1.020030', 'Ignore underscores for numify';
+        $v = $CLASS->new("1.02_003");
+        is $v->numify, '1.020030', 'Ignore underscores for numify';
     }
 }
 

--- a/t/test-all
+++ b/t/test-all
@@ -3,23 +3,23 @@
 # test first with Makefile.PL
 foreach my $perl qw(perl5.00504 perl5.6.2 perl5.8.9 perl5.10.0) {
     foreach my $flag ('', '--perl-only') {
-	system($perl, "Makefile.PL", $flag) == 0 
-	    or die "Couldn't make with $perl";
-	system(qw(make test)) == 0 
-	    or die "Failed to make test with $perl";
-	system(qw(make distclean)) == 0 
-	    or die "Unable to cleanup with $perl";
+        system($perl, "Makefile.PL", $flag) == 0 
+            or die "Couldn't make with $perl";
+        system(qw(make test)) == 0 
+            or die "Failed to make test with $perl";
+        system(qw(make distclean)) == 0 
+            or die "Unable to cleanup with $perl";
     }
 }
 
 # now test first with Build.PL
 foreach my $perl qw(perl5.6.2 perl5.8.9 perl5.10.0) {
     foreach my $flag ('', '--perl-only') {
-	system($perl, "Build.PL", $flag) == 0 
-	    or die "Couldn't make with $perl";
-	system(qw(./Build test)) == 0 
-	    or die "Failed to make test with $perl";
-	system(qw(./Build distclean)) == 0 
-	    or die "Unable to cleanup with $perl";
+        system($perl, "Build.PL", $flag) == 0 
+            or die "Couldn't make with $perl";
+        system(qw(./Build test)) == 0 
+            or die "Failed to make test with $perl";
+        system(qw(./Build distclean)) == 0 
+            or die "Unable to cleanup with $perl";
     }
 }

--- a/vperl/vpp.pm
+++ b/vperl/vpp.pm
@@ -3,17 +3,17 @@ package charstar;
 # so that prescan_version can use the same code as in C
 
 use overload (
-    '""'	=> \&thischar,
-    '0+'	=> \&thischar,
-    '++'	=> \&increment,
-    '--'	=> \&decrement,
-    '+'		=> \&plus,
-    '-'		=> \&minus,
-    '*'		=> \&multiply,
-    'cmp'	=> \&cmp,
-    '<=>'	=> \&spaceship,
-    'bool'	=> \&thischar,
-    '='		=> \&clone,
+    '""'    => \&thischar,
+    '0+'    => \&thischar,
+    '++'    => \&increment,
+    '--'    => \&decrement,
+    '+'     => \&plus,
+    '-'     => \&minus,
+    '*'     => \&multiply,
+    'cmp'   => \&cmp,
+    '<=>'   => \&spaceship,
+    'bool'  => \&thischar,
+    '='     => \&clone,
 );
 
 sub new {
@@ -21,8 +21,8 @@ sub new {
     my $class = ref($self) || $self;
 
     my $obj = {
-	string  => [split(//,$string)],
-	current => 0,
+        string  => [split(//,$string)],
+        current => 0,
     };
     return bless $obj, $class;
 }
@@ -32,10 +32,10 @@ sub thischar {
     my $last = $#{$self->{string}};
     my $curr = $self->{current};
     if ($curr >= 0 && $curr <= $last) {
-	return $self->{string}->[$curr];
+        return $self->{string}->[$curr];
     }
     else {
-	return '';
+        return '';
     }
 }
 
@@ -72,7 +72,7 @@ sub multiply {
 sub spaceship {
     my ($left, $right, $swapped) = @_;
     unless (ref($right)) { # not an object already
-	$right = $left->new($right);
+        $right = $left->new($right);
     }
     return $left->{current} <=> $right->{current};
 }
@@ -80,10 +80,10 @@ sub spaceship {
 sub cmp {
     my ($left, $right, $swapped) = @_;
     unless (ref($right)) { # not an object already
-	if (length($right) == 1) { # comparing single character only
-	    return $left->thischar cmp $right;
-	}
-	$right = $left->new($right);
+          if (length($right) == 1) { # comparing single character only
+              return $left->thischar cmp $right;
+          }
+          $right = $left->new($right);
     }
     return $left->currstr cmp $right->currstr;
 }
@@ -97,8 +97,8 @@ sub bool {
 sub clone {
     my ($left, $right, $swapped) = @_;
     $right = {
-	string  => [@{$left->{string}}],
-	current => $left->{current},
+        string  => [@{$left->{string}}],
+        current => $left->{current},
     };
     return bless $right, ref($left);
 }
@@ -108,7 +108,7 @@ sub currstr {
     my $curr = $self->{current};
     my $last = $#{$self->{string}};
     if (defined($s) && $s->{current} < $last) {
-	$last = $s->{current};
+        $last = $s->{current};
     }
 
     my $string = join('', @{$self->{string}}[$curr..$last]);
@@ -163,55 +163,55 @@ sub import {
 
     # Set up any derived class
     unless ($class eq $CLASS) {
-	local $^W;
-	*{$class.'::declare'} =  \&{$CLASS.'::declare'};
-	*{$class.'::qv'} = \&{$CLASS.'::qv'};
+        local $^W;
+        *{$class.'::declare'} =  \&{$CLASS.'::declare'};
+        *{$class.'::qv'} = \&{$CLASS.'::qv'};
     }
 
     my %args;
     if (@_) { # any remaining terms are arguments
-	map { $args{$_} = 1 } @_
+        map { $args{$_} = 1 } @_
     }
     else { # no parameters at all on use line
-	%args =
-	(
-	    qv => 1,
-	    'UNIVERSAL::VERSION' => 1,
-	);
+        %args =
+        (
+            qv => 1,
+            'UNIVERSAL::VERSION' => 1,
+        );
     }
 
     my $callpkg = caller();
 
     if (exists($args{declare})) {
-	*{$callpkg.'::declare'} =
-	    sub {return $class->declare(shift) }
-	  unless defined(&{$callpkg.'::declare'});
+        *{$callpkg.'::declare'} =
+            sub {return $class->declare(shift) }
+          unless defined(&{$callpkg.'::declare'});
     }
 
     if (exists($args{qv})) {
-	*{$callpkg.'::qv'} =
-	    sub {return $class->qv(shift) }
-	  unless defined(&{$callpkg.'::qv'});
+        *{$callpkg.'::qv'} =
+            sub {return $class->qv(shift) }
+          unless defined(&{$callpkg.'::qv'});
     }
 
     if (exists($args{'UNIVERSAL::VERSION'})) {
-	no warnings qw/redefine/;
-	*UNIVERSAL::VERSION
-		= \&{$CLASS.'::_VERSION'};
+        no warnings qw/redefine/;
+        *UNIVERSAL::VERSION
+            = \&{$CLASS.'::_VERSION'};
     }
 
     if (exists($args{'VERSION'})) {
-	*{$callpkg.'::VERSION'} = \&{$CLASS.'::_VERSION'};
+        *{$callpkg.'::VERSION'} = \&{$CLASS.'::_VERSION'};
     }
 
     if (exists($args{'is_strict'})) {
-	*{$callpkg.'::is_strict'} = \&{$CLASS.'::is_strict'}
-	  unless defined(&{$callpkg.'::is_strict'});
+        *{$callpkg.'::is_strict'} = \&{$CLASS.'::is_strict'}
+          unless defined(&{$callpkg.'::is_strict'});
     }
 
     if (exists($args{'is_lax'})) {
-	*{$callpkg.'::is_lax'} = \&{$CLASS.'::is_lax'}
-	  unless defined(&{$callpkg.'::is_lax'});
+        *{$callpkg.'::is_lax'} = \&{$CLASS.'::is_lax'}
+          unless defined(&{$callpkg.'::is_lax'});
     }
 }
 
@@ -239,7 +239,7 @@ sub isSPACE {
 sub BADVERSION {
     my ($s, $errstr, $error) = @_;
     if ($errstr) {
-	$$errstr = $error;
+        $$errstr = $error;
     }
     return $s;
 }
@@ -254,205 +254,205 @@ sub prescan_version {
     my $d = $s;
 
     if ($qv && isDIGIT($d)) {
-	goto dotted_decimal_version;
+        goto dotted_decimal_version;
     }
 
     if ($d eq 'v') { # explicit v-string
-	$d++;
-	if (isDIGIT($d)) {
-	    $qv = TRUE;
-	}
-	else { # degenerate v-string
-	    # requires v1.2.3
-	    return BADVERSION($s,$errstr,"Invalid version format (dotted-decimal versions require at least three parts)");
-	}
+        $d++;
+        if (isDIGIT($d)) {
+            $qv = TRUE;
+        }
+        else { # degenerate v-string
+            # requires v1.2.3
+            return BADVERSION($s,$errstr,"Invalid version format (dotted-decimal versions require at least three parts)");
+        }
 
 dotted_decimal_version:
-	if ($strict && $d eq '0' && isDIGIT($d+1)) {
-	    # no leading zeros allowed
-	    return BADVERSION($s,$errstr,"Invalid version format (no leading zeros)");
-	}
+        if ($strict && $d eq '0' && isDIGIT($d+1)) {
+            # no leading zeros allowed
+            return BADVERSION($s,$errstr,"Invalid version format (no leading zeros)");
+        }
 
-	while (isDIGIT($d)) { 	# integer part
-	    $d++;
-	}
+        while (isDIGIT($d)) {   # integer part
+            $d++;
+        }
 
-	if ($d eq '.')
-	{
-	    $saw_decimal++;
-	    $d++; 		# decimal point
-	}
-	else
-	{
-	    if ($strict) {
-		# require v1.2.3
-		return BADVERSION($s,$errstr,"Invalid version format (dotted-decimal versions require at least three parts)");
-	    }
-	    else {
-		goto version_prescan_finish;
-	    }
-	}
+        if ($d eq '.')
+        {
+            $saw_decimal++;
+            $d++;     # decimal point
+        }
+        else
+        {
+            if ($strict) {
+            # require v1.2.3
+            return BADVERSION($s,$errstr,"Invalid version format (dotted-decimal versions require at least three parts)");
+            }
+            else {
+            goto version_prescan_finish;
+            }
+        }
 
-	{
-	    my $i = 0;
-	    my $j = 0;
-	    while (isDIGIT($d)) {	# just keep reading
-		$i++;
-		while (isDIGIT($d)) {
-		    $d++; $j++;
-		    # maximum 3 digits between decimal
-		    if ($strict && $j > 3) {
-			return BADVERSION($s,$errstr,"Invalid version format (maximum 3 digits between decimals)");
-		    }
-		}
-		if ($d eq '_') {
-		    if ($strict) {
-			return BADVERSION($s,$errstr,"Invalid version format (no underscores)");
-		    }
-		    if ( $alpha ) {
-			return BADVERSION($s,$errstr,"Invalid version format (multiple underscores)");
-		    }
-		    $d++;
-		    $alpha = TRUE;
-		}
-		elsif ($d eq '.') {
-		    if ($alpha) {
-			return BADVERSION($s,$errstr,"Invalid version format (underscores before decimal)");
-		    }
-		    $saw_decimal++;
-		    $d++;
-		}
-		elsif (!isDIGIT($d)) {
-		    last;
-		}
-		$j = 0;
-	    }
+        {
+            my $i = 0;
+            my $j = 0;
+            while (isDIGIT($d)) {   # just keep reading
+                $i++;
+                while (isDIGIT($d)) {
+                    $d++; $j++;
+                    # maximum 3 digits between decimal
+                    if ($strict && $j > 3) {
+                        return BADVERSION($s,$errstr,"Invalid version format (maximum 3 digits between decimals)");
+                    }
+                }
+                if ($d eq '_') {
+                    if ($strict) {
+                        return BADVERSION($s,$errstr,"Invalid version format (no underscores)");
+                    }
+                    if ( $alpha ) {
+                        return BADVERSION($s,$errstr,"Invalid version format (multiple underscores)");
+                    }
+                    $d++;
+                    $alpha = TRUE;
+                }
+                elsif ($d eq '.') {
+                    if ($alpha) {
+                        return BADVERSION($s,$errstr,"Invalid version format (underscores before decimal)");
+                    }
+                    $saw_decimal++;
+                    $d++;
+                }
+                elsif (!isDIGIT($d)) {
+                    last;
+                }
+                $j = 0;
+            }
 
-	    if ($strict && $i < 2) {
-		# requires v1.2.3
-		return BADVERSION($s,$errstr,"Invalid version format (dotted-decimal versions require at least three parts)");
-	    }
-	}
-    } 					# end if dotted-decimal
+            if ($strict && $i < 2) {
+                # requires v1.2.3
+                return BADVERSION($s,$errstr,"Invalid version format (dotted-decimal versions require at least three parts)");
+            }
+        }
+    }                   # end if dotted-decimal
     else
-    {					# decimal versions
-	my $j = 0;
-	# special $strict case for leading '.' or '0'
-	if ($strict) {
-	    if ($d eq '.') {
-		return BADVERSION($s,$errstr,"Invalid version format (0 before decimal required)");
-	    }
-	    if ($d eq '0' && isDIGIT($d+1)) {
-		return BADVERSION($s,$errstr,"Invalid version format (no leading zeros)");
-	    }
-	}
+    {                   # decimal versions
+        my $j = 0;
+        # special $strict case for leading '.' or '0'
+        if ($strict) {
+            if ($d eq '.') {
+                return BADVERSION($s,$errstr,"Invalid version format (0 before decimal required)");
+            }
+            if ($d eq '0' && isDIGIT($d+1)) {
+                return BADVERSION($s,$errstr,"Invalid version format (no leading zeros)");
+            }
+        }
 
-	# and we never support negative version numbers
-	if ($d eq '-') {
-	    return BADVERSION($s,$errstr,"Invalid version format (negative version number)");
-	}
+        # and we never support negative version numbers
+        if ($d eq '-') {
+            return BADVERSION($s,$errstr,"Invalid version format (negative version number)");
+        }
 
-	# consume all of the integer part
-	while (isDIGIT($d)) {
-	    $d++;
-	}
+        # consume all of the integer part
+        while (isDIGIT($d)) {
+            $d++;
+        }
 
-	# look for a fractional part
-	if ($d eq '.') {
-	    # we found it, so consume it
-	    $saw_decimal++;
-	    $d++;
-	}
-	elsif (!$d || $d eq ';' || isSPACE($d) || $d eq '}') {
-	    if ( $d == $s ) {
-		# found nothing
-		return BADVERSION($s,$errstr,"Invalid version format (version required)");
-	    }
-	    # found just an integer
-	    goto version_prescan_finish;
-	}
-	elsif ( $d == $s ) {
-	    # didn't find either integer or period
-	    return BADVERSION($s,$errstr,"Invalid version format (non-numeric data)");
-	}
-	elsif ($d eq '_') {
-	    # underscore can't come after integer part
-	    if ($strict) {
-		return BADVERSION($s,$errstr,"Invalid version format (no underscores)");
-	    }
-	    elsif (isDIGIT($d+1)) {
-		return BADVERSION($s,$errstr,"Invalid version format (alpha without decimal)");
-	    }
-	    else {
-		return BADVERSION($s,$errstr,"Invalid version format (misplaced underscore)");
-	    }
-	}
-	elsif ($d) {
-	    # anything else after integer part is just invalid data
-	    return BADVERSION($s,$errstr,"Invalid version format (non-numeric data)");
-	}
+        # look for a fractional part
+        if ($d eq '.') {
+            # we found it, so consume it
+            $saw_decimal++;
+            $d++;
+        }
+        elsif (!$d || $d eq ';' || isSPACE($d) || $d eq '}') {
+            if ( $d == $s ) {
+                # found nothing
+                return BADVERSION($s,$errstr,"Invalid version format (version required)");
+            }
+            # found just an integer
+            goto version_prescan_finish;
+        }
+        elsif ( $d == $s ) {
+            # didn't find either integer or period
+            return BADVERSION($s,$errstr,"Invalid version format (non-numeric data)");
+        }
+        elsif ($d eq '_') {
+            # underscore can't come after integer part
+            if ($strict) {
+                return BADVERSION($s,$errstr,"Invalid version format (no underscores)");
+            }
+            elsif (isDIGIT($d+1)) {
+                return BADVERSION($s,$errstr,"Invalid version format (alpha without decimal)");
+            }
+            else {
+                return BADVERSION($s,$errstr,"Invalid version format (misplaced underscore)");
+            }
+        }
+        elsif ($d) {
+            # anything else after integer part is just invalid data
+            return BADVERSION($s,$errstr,"Invalid version format (non-numeric data)");
+        }
 
-	# scan the fractional part after the decimal point
-	if ($d && !isDIGIT($d) && ($strict || ! ($d eq ';' || isSPACE($d) || $d eq '}') )) {
-		# $strict or lax-but-not-the-end
-		return BADVERSION($s,$errstr,"Invalid version format (fractional part required)");
-	}
+        # scan the fractional part after the decimal point
+        if ($d && !isDIGIT($d) && ($strict || ! ($d eq ';' || isSPACE($d) || $d eq '}') )) {
+            # $strict or lax-but-not-the-end
+            return BADVERSION($s,$errstr,"Invalid version format (fractional part required)");
+        }
 
-	while (isDIGIT($d)) {
-	    $d++; $j++;
-	    if ($d eq '.' && isDIGIT($d-1)) {
-		if ($alpha) {
-		    return BADVERSION($s,$errstr,"Invalid version format (underscores before decimal)");
-		}
-		if ($strict) {
-		    return BADVERSION($s,$errstr,"Invalid version format (dotted-decimal versions must begin with 'v')");
-		}
-		$d = $s; # start all over again
-		$qv = TRUE;
-		goto dotted_decimal_version;
-	    }
-	    if ($d eq '_') {
-		if ($strict) {
-		    return BADVERSION($s,$errstr,"Invalid version format (no underscores)");
-		}
-		if ( $alpha ) {
-		    return BADVERSION($s,$errstr,"Invalid version format (multiple underscores)");
-		}
-		if ( ! isDIGIT($d+1) ) {
-		    return BADVERSION($s,$errstr,"Invalid version format (misplaced underscore)");
-		}
-		$width = $j;
-		$d++;
-		$alpha = TRUE;
-	    }
-	}
+        while (isDIGIT($d)) {
+            $d++; $j++;
+            if ($d eq '.' && isDIGIT($d-1)) {
+                if ($alpha) {
+                    return BADVERSION($s,$errstr,"Invalid version format (underscores before decimal)");
+                }
+                if ($strict) {
+                    return BADVERSION($s,$errstr,"Invalid version format (dotted-decimal versions must begin with 'v')");
+                }
+                $d = $s; # start all over again
+                $qv = TRUE;
+                goto dotted_decimal_version;
+            }
+            if ($d eq '_') {
+                if ($strict) {
+                    return BADVERSION($s,$errstr,"Invalid version format (no underscores)");
+                }
+                if ( $alpha ) {
+                    return BADVERSION($s,$errstr,"Invalid version format (multiple underscores)");
+                }
+                if ( ! isDIGIT($d+1) ) {
+                    return BADVERSION($s,$errstr,"Invalid version format (misplaced underscore)");
+                }
+                $width = $j;
+                $d++;
+                $alpha = TRUE;
+            }
+        }
     }
 
 version_prescan_finish:
     while (isSPACE($d)) {
-	$d++;
+        $d++;
     }
 
     if ($d && !isDIGIT($d) && (! ($d eq ';' || $d eq '}') )) {
-	# trailing non-numeric data
-	return BADVERSION($s,$errstr,"Invalid version format (non-numeric data)");
+        # trailing non-numeric data
+        return BADVERSION($s,$errstr,"Invalid version format (non-numeric data)");
     }
     if ($saw_decimal > 1 && ($d-1) eq '.') {
-	# no trailing period allowed
-	return BADVERSION($s,$errstr,"Invalid version format (trailing decimal)");
+        # no trailing period allowed
+        return BADVERSION($s,$errstr,"Invalid version format (trailing decimal)");
     }
 
     if (defined $sqv) {
-	$$sqv = $qv;
+        $$sqv = $qv;
     }
     if (defined $swidth) {
-	$$swidth = $width;
+        $$swidth = $width;
     }
     if (defined $ssaw_decimal) {
-	$$ssaw_decimal = $saw_decimal;
+        $$ssaw_decimal = $saw_decimal;
     }
     if (defined $salpha) {
-	$$salpha = $alpha;
+        $$salpha = $alpha;
     }
     return $d;
 }
@@ -472,160 +472,160 @@ sub scan_version {
     $s = new charstar $s;
 
     while (isSPACE($s)) { # leading whitespace is OK
-	$s++;
+        $s++;
     }
 
     $last = prescan_version($s, FALSE, \$errstr, \$qv, \$saw_decimal,
-	\$width, \$alpha);
+        \$width, \$alpha);
 
     if ($errstr) {
-	# 'undef' is a special case and not an error
-	if ( $s ne 'undef') {
-	    require Carp;
-	    Carp::croak($errstr);
-	}
+        # 'undef' is a special case and not an error
+        if ( $s ne 'undef') {
+            require Carp;
+            Carp::croak($errstr);
+        }
     }
 
     $start = $s;
     if ($s eq 'v') {
-	$s++;
+        $s++;
     }
     $pos = $s;
 
     if ( $qv ) {
-	$$rv->{qv} = $qv;
+        $$rv->{qv} = $qv;
     }
     if ( $alpha ) {
-	$$rv->{alpha} = $alpha;
+        $$rv->{alpha} = $alpha;
     }
     if ( !$qv && $width < 3 ) {
-	$$rv->{width} = $width;
+        $$rv->{width} = $width;
     }
 
     while (isDIGIT($pos) || $pos eq '_') {
-	$pos++;
+        $pos++;
     }
     if (!isALPHA($pos)) {
-	my $rev;
+        my $rev;
 
-	for (;;) {
-	    $rev = 0;
-	    {
-  		# this is atoi() that delimits on underscores
-  		my $end = $pos;
-  		my $mult = 1;
-		my $orev;
+        for (;;) {
+            $rev = 0;
+            {
+                # this is atoi() that delimits on underscores
+                my $end = $pos;
+                my $mult = 1;
+                my $orev;
 
-		#  the following if() will only be true after the decimal
-		#  point of a version originally created with a bare
-		#  floating point number, i.e. not quoted in any way
-		#
- 		if ( !$qv && $s > $start && $saw_decimal == 1 ) {
-		    $mult *= 100;
- 		    while ( $s < $end ) {
-			next if $s eq '_';
-			$orev = $rev;
- 			$rev += $s * $mult;
- 			$mult /= 10;
-			if (   (abs($orev) > abs($rev))
-			    || (abs($rev) > $VERSION_MAX )) {
-			    warn("Integer overflow in version %d",
-					   $VERSION_MAX);
-			    $s = $end - 1;
-			    $rev = $VERSION_MAX;
-			    $vinf = 1;
-			}
- 			$s++;
-			if ( $s eq '_' ) {
-			    $s++;
-			}
- 		    }
-  		}
- 		else {
- 		    while (--$end >= $s) {
-			next if $end eq '_';
-			$orev = $rev;
- 			$rev += $end * $mult;
- 			$mult *= 10;
-			if (   (abs($orev) > abs($rev))
-			    || (abs($rev) > $VERSION_MAX )) {
-			    warn("Integer overflow in version");
-			    $end = $s - 1;
-			    $rev = $VERSION_MAX;
-			    $vinf = 1;
-			}
- 		    }
- 		}
-  	    }
+                #  the following if() will only be true after the decimal
+                #  point of a version originally created with a bare
+                #  floating point number, i.e. not quoted in any way
+                #
+                if ( !$qv && $s > $start && $saw_decimal == 1 ) {
+                    $mult *= 100;
+                    while ( $s < $end ) {
+                        next if $s eq '_';
+                        $orev = $rev;
+                        $rev += $s * $mult;
+                        $mult /= 10;
+                        if (   (abs($orev) > abs($rev))
+                            || (abs($rev) > $VERSION_MAX )) {
+                            warn("Integer overflow in version %d",
+                                $VERSION_MAX);
+                            $s = $end - 1;
+                            $rev = $VERSION_MAX;
+                            $vinf = 1;
+                        }
+                        $s++;
+                        if ( $s eq '_' ) {
+                            $s++;
+                        }
+                    }
+                }
+                else {
+                    while (--$end >= $s) {
+                        next if $end eq '_';
+                        $orev = $rev;
+                        $rev += $end * $mult;
+                        $mult *= 10;
+                        if (   (abs($orev) > abs($rev))
+                            || (abs($rev) > $VERSION_MAX )) {
+                            warn("Integer overflow in version");
+                            $end = $s - 1;
+                            $rev = $VERSION_MAX;
+                            $vinf = 1;
+                        }
+                    }
+                }
+            }
 
-  	    # Append revision
-	    push @av, $rev;
-	    if ( $vinf ) {
-		$s = $last;
-		last;
-	    }
-	    elsif ( $pos eq '.' ) {
-		$s = ++$pos;
-	    }
-	    elsif ( $pos eq '_' && isDIGIT($pos+1) ) {
-		$s = ++$pos;
-	    }
-	    elsif ( $pos eq ',' && isDIGIT($pos+1) ) {
-		$s = ++$pos;
-	    }
-	    elsif ( isDIGIT($pos) ) {
-		$s = $pos;
-	    }
-	    else {
-		$s = $pos;
-		last;
-	    }
-	    if ( $qv ) {
-		while ( isDIGIT($pos) || $pos eq '_') {
-		    $pos++;
-		}
-	    }
-	    else {
-		my $digits = 0;
-		while ( ( isDIGIT($pos) || $pos eq '_' ) && $digits < 3 ) {
-		    if ( $pos ne '_' ) {
-			$digits++;
-		    }
-		    $pos++;
-		}
-	    }
-	}
+            # Append revision
+            push @av, $rev;
+            if ( $vinf ) {
+                $s = $last;
+                last;
+            }
+            elsif ( $pos eq '.' ) {
+                $s = ++$pos;
+            }
+            elsif ( $pos eq '_' && isDIGIT($pos+1) ) {
+                $s = ++$pos;
+            }
+            elsif ( $pos eq ',' && isDIGIT($pos+1) ) {
+                $s = ++$pos;
+            }
+            elsif ( isDIGIT($pos) ) {
+                $s = $pos;
+            }
+            else {
+                $s = $pos;
+                last;
+            }
+            if ( $qv ) {
+                while ( isDIGIT($pos) || $pos eq '_') {
+                    $pos++;
+                }
+            }
+            else {
+                my $digits = 0;
+                while ( ( isDIGIT($pos) || $pos eq '_' ) && $digits < 3 ) {
+                    if ( $pos ne '_' ) {
+                        $digits++;
+                    }
+                    $pos++;
+                }
+            }
+        }
     }
     if ( $qv ) { # quoted versions always get at least three terms
-	my $len = $#av;
-	#  This for loop appears to trigger a compiler bug on OS X, as it
-	#  loops infinitely. Yes, len is negative. No, it makes no sense.
-	#  Compiler in question is:
-	#  gcc version 3.3 20030304 (Apple Computer, Inc. build 1640)
-	#  for ( len = 2 - len; len > 0; len-- )
-	#  av_push(MUTABLE_AV(sv), newSViv(0));
-	#
-	$len = 2 - $len;
-	while ($len-- > 0) {
-	    push @av, 0;
-	}
+        my $len = $#av;
+        #  This for loop appears to trigger a compiler bug on OS X, as it
+        #  loops infinitely. Yes, len is negative. No, it makes no sense.
+        #  Compiler in question is:
+        #  gcc version 3.3 20030304 (Apple Computer, Inc. build 1640)
+        #  for ( len = 2 - len; len > 0; len-- )
+        #  av_push(MUTABLE_AV(sv), newSViv(0));
+        #
+        $len = 2 - $len;
+        while ($len-- > 0) {
+            push @av, 0;
+        }
     }
 
     # need to save off the current version string for later
     if ( $vinf ) {
-	$$rv->{original} = "v.Inf";
-	$$rv->{vinf} = 1;
+        $$rv->{original} = "v.Inf";
+        $$rv->{vinf} = 1;
     }
     elsif ( $s > $start ) {
-	$$rv->{original} = $start->currstr($s);
-	if ( $qv && $saw_decimal == 1 && $start ne 'v' ) {
-	    # need to insert a v to be consistent
-	    $$rv->{original} = 'v' . $$rv->{original};
-	}
+        $$rv->{original} = $start->currstr($s);
+        if ( $qv && $saw_decimal == 1 && $start ne 'v' ) {
+            # need to insert a v to be consistent
+            $$rv->{original} = 'v' . $$rv->{original};
+        }
     }
     else {
-	$$rv->{original} = '0';
-	push(@av, 0);
+        $$rv->{original} = '0';
+        push(@av, 0);
     }
 
     # And finally, store the AV in the hash
@@ -633,7 +633,7 @@ sub scan_version {
 
     # fix RT#19517 - special case 'undef' as string
     if ($s eq 'undef') {
-	$s += 5;
+        $s += 5;
     }
 
     return $s;
@@ -642,67 +642,67 @@ sub scan_version {
 sub new {
     my $class = shift;
     unless (defined $class or $#_ > 1) {
-	require Carp;
-	Carp::croak('Usage: version::new(class, version)');
+        require Carp;
+        Carp::croak('Usage: version::new(class, version)');
     }
 
     my $self = bless ({}, ref ($class) || $class);
     my $qv = FALSE;
 
     if ( $#_ == 1 ) { # must be CVS-style
-	$qv = TRUE;
+        $qv = TRUE;
     }
     my $value = pop; # always going to be the last element
 
     if ( ref($value) && eval('$value->isa("version")') ) {
-	# Can copy the elements directly
-	$self->{version} = [ @{$value->{version} } ];
-	$self->{qv} = 1 if $value->{qv};
-	$self->{alpha} = 1 if $value->{alpha};
-	$self->{original} = ''.$value->{original};
-	return $self;
+        # Can copy the elements directly
+        $self->{version} = [ @{$value->{version} } ];
+        $self->{qv} = 1 if $value->{qv};
+        $self->{alpha} = 1 if $value->{alpha};
+        $self->{original} = ''.$value->{original};
+        return $self;
     }
 
     if ( not defined $value or $value =~ /^undef$/ ) {
-	# RT #19517 - special case for undef comparison
-	# or someone forgot to pass a value
-	push @{$self->{version}}, 0;
-	$self->{original} = "0";
-	return ($self);
+        # RT #19517 - special case for undef comparison
+        # or someone forgot to pass a value
+        push @{$self->{version}}, 0;
+        $self->{original} = "0";
+        return ($self);
     }
 
 
     if (ref($value) =~ m/ARRAY|HASH/) {
-	require Carp;
-	Carp::croak("Invalid version format (non-numeric data)");
+        require Carp;
+        Carp::croak("Invalid version format (non-numeric data)");
     }
 
     $value = _un_vstring($value);
 
     if ($Config{d_setlocale}) {
-	use POSIX qw/locale_h/;
-	use if $Config{d_setlocale}, 'locale';
-	my $currlocale = setlocale(LC_ALL);
+        use POSIX qw/locale_h/;
+        use if $Config{d_setlocale}, 'locale';
+        my $currlocale = setlocale(LC_ALL);
 
-	# if the current locale uses commas for decimal points, we
-	# just replace commas with decimal places, rather than changing
-	# locales
-	if ( localeconv()->{decimal_point} eq ',' ) {
-	    $value =~ tr/,/./;
-	}
+        # if the current locale uses commas for decimal points, we
+        # just replace commas with decimal places, rather than changing
+        # locales
+        if ( localeconv()->{decimal_point} eq ',' ) {
+            $value =~ tr/,/./;
+        }
     }
 
     # exponential notation
     if ( $value =~ /\d+.?\d*e[-+]?\d+/ ) {
-	$value = sprintf("%.9f",$value);
-	$value =~ s/(0+)$//; # trim trailing zeros
+        $value = sprintf("%.9f",$value);
+        $value =~ s/(0+)$//; # trim trailing zeros
     }
 
     my $s = scan_version($value, \$self, $qv);
 
     if ($s) { # must be something left over
-	warn(sprintf "Version string '%s' contains invalid data; "
-		   ."ignoring: '%s'", $value, $s);
+        warn(sprintf "Version string '%s' contains invalid data; "
+            ."ignoring: '%s'", $value, $s);
     }
 
     return ($self);
@@ -713,8 +713,8 @@ sub new {
 sub numify {
     my ($self) = @_;
     unless (_verify($self)) {
-	require Carp;
-	Carp::croak("Invalid version object");
+        require Carp;
+        Carp::croak("Invalid version object");
     }
     my $alpha = $self->{alpha} || "";
     my $len = $#{$self->{version}};
@@ -722,16 +722,16 @@ sub numify {
     my $string = sprintf("%d.", $digit );
 
     if ($alpha and warnings::enabled()) {
-	warnings::warn($WARN_CATEGORY, 'alpha->numify() is lossy');
+        warnings::warn($WARN_CATEGORY, 'alpha->numify() is lossy');
     }
 
     for ( my $i = 1 ; $i <= $len ; $i++ ) {
-	$digit = $self->{version}[$i];
-	$string .= sprintf("%03d", $digit);
+        $digit = $self->{version}[$i];
+        $string .= sprintf("%03d", $digit);
     }
 
     if ( $len == 0 ) {
-	$string .= sprintf("000");
+        $string .= sprintf("000");
     }
 
     return $string;
@@ -740,8 +740,8 @@ sub numify {
 sub normal {
     my ($self) = @_;
     unless (_verify($self)) {
-	require Carp;
-	Carp::croak("Invalid version object");
+        require Carp;
+        Carp::croak("Invalid version object");
     }
 
     my $len = $#{$self->{version}};
@@ -749,14 +749,14 @@ sub normal {
     my $string = sprintf("v%d", $digit );
 
     for ( my $i = 1 ; $i <= $len ; $i++ ) {
-	$digit = $self->{version}[$i];
-	$string .= sprintf(".%d", $digit);
+        $digit = $self->{version}[$i];
+        $string .= sprintf(".%d", $digit);
     }
 
     if ( $len <= 2 ) {
-	for ( $len = 2 - $len; $len != 0; $len-- ) {
-	    $string .= sprintf(".%0d", 0);
-	}
+        for ( $len = 2 - $len; $len != 0; $len-- ) {
+            $string .= sprintf(".%0d", 0);
+        }
     }
 
     return $string;
@@ -765,14 +765,14 @@ sub normal {
 sub stringify {
     my ($self) = @_;
     unless (_verify($self)) {
-	require Carp;
-	Carp::croak("Invalid version object");
+        require Carp;
+        Carp::croak("Invalid version object");
     }
     return exists $self->{original}
-    	? $self->{original}
-	: exists $self->{qv}
-	    ? $self->normal
-	    : $self->numify;
+        ? $self->{original}
+        : exists $self->{qv}
+            ? $self->normal
+            : $self->numify;
 }
 
 sub vcmp {
@@ -780,19 +780,19 @@ sub vcmp {
     die "Usage: version::vcmp(lobj, robj, ...)" if @_ < 2;
     my $class = ref($left);
     unless ( UNIVERSAL::isa($right, $class) ) {
-	$right = $class->new($right);
+        $right = $class->new($right);
     }
 
     if ( $swap ) {
-	($left, $right) = ($right, $left);
+        ($left, $right) = ($right, $left);
     }
     unless (_verify($left)) {
-	require Carp;
-	Carp::croak("Invalid version object");
+        require Carp;
+        Carp::croak("Invalid version object");
     }
     unless (_verify($right)) {
-	require Carp;
-	Carp::croak("Invalid version format");
+        require Carp;
+        Carp::croak("Invalid version format");
     }
     my $l = $#{$left->{version}};
     my $r = $#{$right->{version}};
@@ -802,28 +802,28 @@ sub vcmp {
     my $retval = 0;
     my $i = 0;
     while ( $i <= $m && $retval == 0 ) {
-	$retval = $left->{version}[$i] <=> $right->{version}[$i];
-	$i++;
+        $retval = $left->{version}[$i] <=> $right->{version}[$i];
+        $i++;
     }
 
     # possible match except for trailing 0's
     if ( $retval == 0 && $l != $r ) {
-	if ( $l < $r ) {
-	    while ( $i <= $r && $retval == 0 ) {
-		if ( $right->{version}[$i] != 0 ) {
-		    $retval = -1; # not a match after all
-		}
-		$i++;
-	    }
-	}
-	else {
-	    while ( $i <= $l && $retval == 0 ) {
-		if ( $left->{version}[$i] != 0 ) {
-		    $retval = +1; # not a match after all
-		}
-		$i++;
-	    }
-	}
+        if ( $l < $r ) {
+            while ( $i <= $r && $retval == 0 ) {
+                if ( $right->{version}[$i] != 0 ) {
+                    $retval = -1; # not a match after all
+                }
+                $i++;
+            }
+        }
+        else {
+            while ( $i <= $l && $retval == 0 ) {
+                if ( $left->{version}[$i] != 0 ) {
+                    $retval = +1; # not a match after all
+                }
+                $i++;
+            }
+        }
     }
 
     return $retval;
@@ -848,8 +848,8 @@ sub qv {
     my $value = shift;
     my $class = $CLASS;
     if (@_) {
-	$class = ref($value) || $value;
-	$value = shift;
+        $class = ref($value) || $value;
+        $value = shift;
     }
 
     $value = _un_vstring($value);
@@ -869,13 +869,13 @@ sub is_qv {
 sub _verify {
     my ($self) = @_;
     if ( ref($self)
-	&& eval { exists $self->{version} }
-	&& ref($self->{version}) eq 'ARRAY'
-	) {
-	return 1;
+        && eval { exists $self->{version} }
+        && ref($self->{version}) eq 'ARRAY'
+    ) {
+        return 1;
     }
     else {
-	return 0;
+        return 0;
     }
 }
 
@@ -883,9 +883,9 @@ sub _is_non_alphanumeric {
     my $s = shift;
     $s = new charstar $s;
     while ($s) {
-	return 0 if isSPACE($s); # early out
-	return 1 unless (isALPHA($s) || isDIGIT($s) || $s =~ /[.-]/);
-	$s++;
+        return 0 if isSPACE($s); # early out
+        return 1 unless (isALPHA($s) || isDIGIT($s) || $s =~ /[.-]/);
+        $s++;
     }
     return 0;
 }
@@ -894,19 +894,19 @@ sub _un_vstring {
     my $value = shift;
     # may be a v-string
     if ( length($value) >= 1 && $value !~ /[,._]/
-	&& _is_non_alphanumeric($value)) {
-	my $tvalue;
-	if ( $] >= 5.008_001 ) {
-	    $tvalue = _find_magic_vstring($value);
-	    $value = $tvalue if length $tvalue;
-	}
-	elsif ( $] >= 5.006_000 ) {
-	    $tvalue = sprintf("v%vd",$value);
-	    if ( $tvalue =~ /^v\d+(\.\d+)*$/ ) {
-		# must be a v-string
-		$value = $tvalue;
-	    }
-	}
+        && _is_non_alphanumeric($value)) {
+        my $tvalue;
+        if ( $] >= 5.008_001 ) {
+            $tvalue = _find_magic_vstring($value);
+            $value = $tvalue if length $tvalue;
+        }
+        elsif ( $] >= 5.006_000 ) {
+            $tvalue = sprintf("v%vd",$value);
+            if ( $tvalue =~ /^v\d+(\.\d+)*$/ ) {
+                # must be a v-string
+                $value = $tvalue;
+            }
+        }
     }
     return $value;
 }
@@ -918,14 +918,14 @@ sub _find_magic_vstring {
     my $sv = B::svref_2object(\$value);
     my $magic = ref($sv) eq 'B::PVMG' ? $sv->MAGIC : undef;
     while ( $magic ) {
-	if ( $magic->TYPE eq 'V' ) {
-	    $tvalue = $magic->PTR;
-	    $tvalue =~ s/^v?(.+)$/v$1/;
-	    last;
-	}
-	else {
-	    $magic = $magic->MOREMAGIC;
-	}
+        if ( $magic->TYPE eq 'V' ) {
+            $tvalue = $magic->PTR;
+            $tvalue =~ s/^v?(.+)$/v$1/;
+            last;
+        }
+        else {
+            $magic = $magic->MOREMAGIC;
+        }
     }
     $tvalue =~ tr/_//d;
     return $tvalue;
@@ -937,53 +937,53 @@ sub _VERSION {
 
     no strict 'refs';
     if ( exists $INC{"$class.pm"} and not %{"$class\::"} and $] >= 5.008) {
-	 # file but no package
-	require Carp;
-	Carp::croak( "$class defines neither package nor VERSION"
-	    ."--version check failed");
+        # file but no package
+        require Carp;
+        Carp::croak( "$class defines neither package nor VERSION"
+            ."--version check failed");
     }
 
     my $version = eval "\$$class\::VERSION";
     if ( defined $version ) {
-	local $^W if $] <= 5.008;
-	$version = version::vpp->new($version);
+        local $^W if $] <= 5.008;
+        $version = version::vpp->new($version);
     }
 
     if ( defined $req ) {
-	unless ( defined $version ) {
-	    require Carp;
-	    my $msg =  $] < 5.006
-	    ? "$class version $req required--this is only version "
-	    : "$class does not define \$$class\::VERSION"
-	      ."--version check failed";
+        unless ( defined $version ) {
+            require Carp;
+            my $msg =  $] < 5.006
+                ? "$class version $req required--this is only version "
+                : "$class does not define \$$class\::VERSION"
+                ."--version check failed";
 
-	    if ( $ENV{VERSION_DEBUG} ) {
-		Carp::confess($msg);
-	    }
-	    else {
-		Carp::croak($msg);
-	    }
-	}
+            if ( $ENV{VERSION_DEBUG} ) {
+                Carp::confess($msg);
+            }
+            else {
+                Carp::croak($msg);
+            }
+        }
 
-	$req = version::vpp->new($req);
+        $req = version::vpp->new($req);
 
-	if ( $req > $version ) {
-	    require Carp;
-	    if ( $req->is_qv ) {
-		Carp::croak(
-		    sprintf ("%s version %s required--".
-			"this is only version %s", $class,
-			$req->normal, $version->normal)
-		);
-	    }
-	    else {
-		Carp::croak(
-		    sprintf ("%s version %s required--".
-			"this is only version %s", $class,
-			$req->stringify, $version->stringify)
-		);
-	    }
-	}
+        if ( $req > $version ) {
+            require Carp;
+            if ( $req->is_qv ) {
+                Carp::croak(
+                    sprintf ("%s version %s required--".
+                        "this is only version %s", $class,
+                        $req->normal, $version->normal)
+                );
+            }
+            else {
+                Carp::croak(
+                    sprintf ("%s version %s required--".
+                        "this is only version %s", $class,
+                        $req->stringify, $version->stringify)
+                );
+            }
+        }
     }
 
     return defined $version ? $version->stringify : undef;

--- a/vutil/vutil.c
+++ b/vutil/vutil.c
@@ -23,8 +23,8 @@ Perl_prescan_version2(pTHX_ const char *s, bool strict,
 #else
 Perl_prescan_version(pTHX_ const char *s, bool strict,
 #endif
-		     const char **errstr,
-		     bool *sqv, int *ssaw_decimal, int *swidth, bool *salpha) {
+        const char **errstr,
+        bool *sqv, int *ssaw_decimal, int *swidth, bool *salpha) {
     bool qv = (sqv ? *sqv : FALSE);
     int width = 3;
     int saw_decimal = 0;
@@ -35,200 +35,200 @@ Perl_prescan_version(pTHX_ const char *s, bool strict,
     PERL_UNUSED_CONTEXT;
 
     if (qv && isDIGIT(*d))
-	goto dotted_decimal_version;
+        goto dotted_decimal_version;
 
     if (*d == 'v') { /* explicit v-string */
-	d++;
-	if (isDIGIT(*d)) {
-	    qv = TRUE;
-	}
-	else { /* degenerate v-string */
-	    /* requires v1.2.3 */
-	    BADVERSION(s,errstr,"Invalid version format (dotted-decimal versions require at least three parts)");
-	}
+        d++;
+        if (isDIGIT(*d)) {
+            qv = TRUE;
+        }
+        else { /* degenerate v-string */
+            /* requires v1.2.3 */
+            BADVERSION(s,errstr,"Invalid version format (dotted-decimal versions require at least three parts)");
+        }
 
 dotted_decimal_version:
-	if (strict && d[0] == '0' && isDIGIT(d[1])) {
-	    /* no leading zeros allowed */
-	    BADVERSION(s,errstr,"Invalid version format (no leading zeros)");
-	}
+        if (strict && d[0] == '0' && isDIGIT(d[1])) {
+            /* no leading zeros allowed */
+            BADVERSION(s,errstr,"Invalid version format (no leading zeros)");
+        }
 
-	while (isDIGIT(*d)) 	/* integer part */
-	    d++;
+        while (isDIGIT(*d))                 /* integer part */
+            d++;
 
-	if (*d == '.')
-	{
-	    saw_decimal++;
-	    d++; 		/* decimal point */
-	}
-	else
-	{
-	    if (strict) {
-		/* require v1.2.3 */
-		BADVERSION(s,errstr,"Invalid version format (dotted-decimal versions require at least three parts)");
-	    }
-	    else {
-		goto version_prescan_finish;
-	    }
-	}
+        if (*d == '.')
+        {
+            saw_decimal++;
+            d++;                            /* decimal point */
+        }
+        else
+        {
+            if (strict) {
+                /* require v1.2.3 */
+                BADVERSION(s,errstr,"Invalid version format (dotted-decimal versions require at least three parts)");
+            }
+            else {
+                goto version_prescan_finish;
+            }
+        }
 
-	{
-	    int i = 0;
-	    int j = 0;
-	    while (isDIGIT(*d)) {	/* just keep reading */
-		i++;
-		while (isDIGIT(*d)) {
-		    d++; j++;
-		    /* maximum 3 digits between decimal */
-		    if (strict && j > 3) {
-			BADVERSION(s,errstr,"Invalid version format (maximum 3 digits between decimals)");
-		    }
-		}
-		if (*d == '_') {
-		    if (strict) {
-			BADVERSION(s,errstr,"Invalid version format (no underscores)");
-		    }
-		    if ( alpha ) {
-			BADVERSION(s,errstr,"Invalid version format (multiple underscores)");
-		    }
-		    d++;
-		    alpha = TRUE;
-		}
-		else if (*d == '.') {
-		    if (alpha) {
-			BADVERSION(s,errstr,"Invalid version format (underscores before decimal)");
-		    }
-		    saw_decimal++;
-		    d++;
-		}
-		else if (!isDIGIT(*d)) {
-		    break;
-		}
-		j = 0;
-	    }
+        {
+            int i = 0;
+            int j = 0;
+            while (isDIGIT(*d)) {           /* just keep reading */
+                i++;
+                while (isDIGIT(*d)) {
+                    d++; j++;
+                    /* maximum 3 digits between decimal */
+                    if (strict && j > 3) {
+                        BADVERSION(s,errstr,"Invalid version format (maximum 3 digits between decimals)");
+                    }
+                }
+                if (*d == '_') {
+                    if (strict) {
+                        BADVERSION(s,errstr,"Invalid version format (no underscores)");
+                    }
+                    if ( alpha ) {
+                        BADVERSION(s,errstr,"Invalid version format (multiple underscores)");
+                    }
+                    d++;
+                    alpha = TRUE;
+                }
+                else if (*d == '.') {
+                    if (alpha) {
+                        BADVERSION(s,errstr,"Invalid version format (underscores before decimal)");
+                    }
+                    saw_decimal++;
+                    d++;
+                }
+                else if (!isDIGIT(*d)) {
+                    break;
+                }
+                j = 0;
+            }
 
-	    if (strict && i < 2) {
-		/* requires v1.2.3 */
-		BADVERSION(s,errstr,"Invalid version format (dotted-decimal versions require at least three parts)");
-	    }
-	}
-    } 					/* end if dotted-decimal */
+            if (strict && i < 2) {
+                /* requires v1.2.3 */
+                BADVERSION(s,errstr,"Invalid version format (dotted-decimal versions require at least three parts)");
+            }
+        }
+    }                                       /* end if dotted-decimal */
     else
-    {					/* decimal versions */
-	int j = 0;			/* may need this later */
-	/* special strict case for leading '.' or '0' */
-	if (strict) {
-	    if (*d == '.') {
-		BADVERSION(s,errstr,"Invalid version format (0 before decimal required)");
-	    }
-	    if (*d == '0' && isDIGIT(d[1])) {
-		BADVERSION(s,errstr,"Invalid version format (no leading zeros)");
-	    }
-	}
+    {                                       /* decimal versions */
+        int j = 0;                          /* may need this later */
+        /* special strict case for leading '.' or '0' */
+        if (strict) {
+            if (*d == '.') {
+                BADVERSION(s,errstr,"Invalid version format (0 before decimal required)");
+            }
+            if (*d == '0' && isDIGIT(d[1])) {
+                BADVERSION(s,errstr,"Invalid version format (no leading zeros)");
+            }
+        }
 
-	/* and we never support negative versions */
-	if ( *d == '-') {
-	    BADVERSION(s,errstr,"Invalid version format (negative version number)");
-	}
+        /* and we never support negative versions */
+        if ( *d == '-') {
+            BADVERSION(s,errstr,"Invalid version format (negative version number)");
+        }
 
-	/* consume all of the integer part */
-	while (isDIGIT(*d))
-	    d++;
+        /* consume all of the integer part */
+        while (isDIGIT(*d))
+            d++;
 
-	/* look for a fractional part */
-	if (*d == '.') {
-	    /* we found it, so consume it */
-	    saw_decimal++;
-	    d++;
-	}
-	else if (!*d || *d == ';' || isSPACE(*d) || *d == '{' || *d == '}') {
-	    if ( d == s ) {
-		/* found nothing */
-		BADVERSION(s,errstr,"Invalid version format (version required)");
-	    }
-	    /* found just an integer */
-	    goto version_prescan_finish;
-	}
-	else if ( d == s ) {
-	    /* didn't find either integer or period */
-	    BADVERSION(s,errstr,"Invalid version format (non-numeric data)");
-	}
-	else if (*d == '_') {
-	    /* underscore can't come after integer part */
-	    if (strict) {
-		BADVERSION(s,errstr,"Invalid version format (no underscores)");
-	    }
-	    else if (isDIGIT(d[1])) {
-		BADVERSION(s,errstr,"Invalid version format (alpha without decimal)");
-	    }
-	    else {
-		BADVERSION(s,errstr,"Invalid version format (misplaced underscore)");
-	    }
-	}
-	else {
-	    /* anything else after integer part is just invalid data */
-	    BADVERSION(s,errstr,"Invalid version format (non-numeric data)");
-	}
+        /* look for a fractional part */
+        if (*d == '.') {
+            /* we found it, so consume it */
+            saw_decimal++;
+            d++;
+        }
+        else if (!*d || *d == ';' || isSPACE(*d) || *d == '{' || *d == '}') {
+            if ( d == s ) {
+                /* found nothing */
+                BADVERSION(s,errstr,"Invalid version format (version required)");
+            }
+            /* found just an integer */
+            goto version_prescan_finish;
+        }
+        else if ( d == s ) {
+            /* didn't find either integer or period */
+            BADVERSION(s,errstr,"Invalid version format (non-numeric data)");
+        }
+        else if (*d == '_') {
+            /* underscore can't come after integer part */
+            if (strict) {
+                BADVERSION(s,errstr,"Invalid version format (no underscores)");
+            }
+            else if (isDIGIT(d[1])) {
+                BADVERSION(s,errstr,"Invalid version format (alpha without decimal)");
+            }
+            else {
+                BADVERSION(s,errstr,"Invalid version format (misplaced underscore)");
+            }
+        }
+        else {
+            /* anything else after integer part is just invalid data */
+            BADVERSION(s,errstr,"Invalid version format (non-numeric data)");
+        }
 
-	/* scan the fractional part after the decimal point*/
+        /* scan the fractional part after the decimal point*/
 
-	if (!isDIGIT(*d) && (strict || ! (!*d || *d == ';' || isSPACE(*d) || *d == '{' || *d == '}') )) {
-		/* strict or lax-but-not-the-end */
-		BADVERSION(s,errstr,"Invalid version format (fractional part required)");
-	}
+        if (!isDIGIT(*d) && (strict || ! (!*d || *d == ';' || isSPACE(*d) || *d == '{' || *d == '}') )) {
+            /* strict or lax-but-not-the-end */
+            BADVERSION(s,errstr,"Invalid version format (fractional part required)");
+        }
 
-	while (isDIGIT(*d)) {
-	    d++; j++;
-	    if (*d == '.' && isDIGIT(d[-1])) {
-		if (alpha) {
-		    BADVERSION(s,errstr,"Invalid version format (underscores before decimal)");
-		}
-		if (strict) {
-		    BADVERSION(s,errstr,"Invalid version format (dotted-decimal versions must begin with 'v')");
-		}
-		d = (char *)s; 		/* start all over again */
-		qv = TRUE;
-		goto dotted_decimal_version;
-	    }
-	    if (*d == '_') {
-		if (strict) {
-		    BADVERSION(s,errstr,"Invalid version format (no underscores)");
-		}
-		if ( alpha ) {
-		    BADVERSION(s,errstr,"Invalid version format (multiple underscores)");
-		}
-		if ( ! isDIGIT(d[1]) ) {
-		    BADVERSION(s,errstr,"Invalid version format (misplaced underscore)");
-		}
-		width = j;
-		d++;
-		alpha = TRUE;
-	    }
-	}
+        while (isDIGIT(*d)) {
+            d++; j++;
+            if (*d == '.' && isDIGIT(d[-1])) {
+                if (alpha) {
+                    BADVERSION(s,errstr,"Invalid version format (underscores before decimal)");
+                }
+                if (strict) {
+                    BADVERSION(s,errstr,"Invalid version format (dotted-decimal versions must begin with 'v')");
+                }
+                d = (char *)s;                  /* start all over again */
+                qv = TRUE;
+                goto dotted_decimal_version;
+            }
+            if (*d == '_') {
+                if (strict) {
+                    BADVERSION(s,errstr,"Invalid version format (no underscores)");
+                }
+                if ( alpha ) {
+                    BADVERSION(s,errstr,"Invalid version format (multiple underscores)");
+                }
+                if ( ! isDIGIT(d[1]) ) {
+                    BADVERSION(s,errstr,"Invalid version format (misplaced underscore)");
+                }
+                width = j;
+                d++;
+                alpha = TRUE;
+            }
+        }
     }
 
 version_prescan_finish:
     while (isSPACE(*d))
-	d++;
+        d++;
 
     if (!isDIGIT(*d) && (! (!*d || *d == ';' || *d == '{' || *d == '}') )) {
-	/* trailing non-numeric data */
-	BADVERSION(s,errstr,"Invalid version format (non-numeric data)");
+        /* trailing non-numeric data */
+        BADVERSION(s,errstr,"Invalid version format (non-numeric data)");
     }
     if (saw_decimal > 1 && d[-1] == '.') {
-	/* no trailing period allowed */
-	BADVERSION(s,errstr,"Invalid version format (trailing decimal)");
+        /* no trailing period allowed */
+        BADVERSION(s,errstr,"Invalid version format (trailing decimal)");
     }
 
 
     if (sqv)
-	*sqv = qv;
+        *sqv = qv;
     if (swidth)
-	*swidth = width;
+        *swidth = width;
     if (ssaw_decimal)
-	*ssaw_decimal = saw_decimal;
+        *ssaw_decimal = saw_decimal;
     if (salpha)
-	*salpha = alpha;
+        *salpha = alpha;
     return d;
 }
 
@@ -275,19 +275,19 @@ Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv)
     PERL_ARGS_ASSERT_SCAN_VERSION;
 
     while (isSPACE(*s)) /* leading whitespace is OK */
-	s++;
+        s++;
 
     last = PRESCAN_VERSION(s, FALSE, &errstr, &qv, &saw_decimal, &width, &alpha);
     if (errstr) {
-	/* "undef" is a special case and not an error */
-	if ( ! ( *s == 'u' && strEQ(s+1,"ndef")) ) {
-	    Perl_croak(aTHX_ "%s", errstr);
-	}
+        /* "undef" is a special case and not an error */
+        if ( ! ( *s == 'u' && strEQ(s+1,"ndef")) ) {
+            Perl_croak(aTHX_ "%s", errstr);
+        }
     }
 
     start = s;
     if (*s == 'v')
-	s++;
+        s++;
     pos = s;
 
     /* Now that we are through the prescan, start creating the object */
@@ -300,66 +300,66 @@ Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv)
 #endif
 
     if ( qv )
-	(void)hv_stores(MUTABLE_HV(hv), "qv", newSViv(qv));
+        (void)hv_stores(MUTABLE_HV(hv), "qv", newSViv(qv));
     if ( alpha )
-	(void)hv_stores(MUTABLE_HV(hv), "alpha", newSViv(alpha));
+        (void)hv_stores(MUTABLE_HV(hv), "alpha", newSViv(alpha));
     if ( !qv && width < 3 )
-	(void)hv_stores(MUTABLE_HV(hv), "width", newSViv(width));
+        (void)hv_stores(MUTABLE_HV(hv), "width", newSViv(width));
 
     while (isDIGIT(*pos) || *pos == '_')
-	pos++;
+        pos++;
     if (!isALPHA(*pos)) {
-	I32 rev;
+        I32 rev;
 
-	for (;;) {
-	    rev = 0;
-	    {
-  		/* this is atoi() that delimits on underscores */
-  		const char *end = pos;
-  		I32 mult = 1;
-		I32 orev;
+        for (;;) {
+            rev = 0;
+            {
+                /* this is atoi() that delimits on underscores */
+                const char *end = pos;
+                I32 mult = 1;
+                I32 orev;
 
-		/* the following if() will only be true after the decimal
-		 * point of a version originally created with a bare
-		 * floating point number, i.e. not quoted in any way
-		 */
-		if ( !qv && s > start && saw_decimal == 1 ) {
-		    mult *= 100;
- 		    while ( s < end ) {
-			if (*s == '_')
-			    continue;
-			orev = rev;
- 			rev += (*s - '0') * mult;
- 			mult /= 10;
-			if (   (PERL_ABS(orev) > PERL_ABS(rev)) 
-			    || (PERL_ABS(rev) > VERSION_MAX )) {
-			    Perl_ck_warner(aTHX_ packWARN(WARN_OVERFLOW), 
-					   "Integer overflow in version %d",VERSION_MAX);
-			    s = end - 1;
-			    rev = VERSION_MAX;
-			    vinf = 1;
-			}
- 			s++;
-			if ( *s == '_' )
-			    s++;
- 		    }
-  		}
- 		else {
- 		    while (--end >= s) {
-			int i;
-			if (*end == '_')
-			    continue;
-			i = (*end - '0');
+                /* the following if() will only be true after the decimal
+                 * point of a version originally created with a bare
+                 * floating point number, i.e. not quoted in any way
+                 */
+                if ( !qv && s > start && saw_decimal == 1 ) {
+                    mult *= 100;
+                    while ( s < end ) {
+                        if (*s == '_')
+                            continue;
+                        orev = rev;
+                        rev += (*s - '0') * mult;
+                        mult /= 10;
+                        if (   (PERL_ABS(orev) > PERL_ABS(rev)) 
+                                || (PERL_ABS(rev) > VERSION_MAX )) {
+                            Perl_ck_warner(aTHX_ packWARN(WARN_OVERFLOW), 
+                                    "Integer overflow in version %d",VERSION_MAX);
+                            s = end - 1;
+                            rev = VERSION_MAX;
+                            vinf = 1;
+                        }
+                        s++;
+                        if ( *s == '_' )
+                            s++;
+                    }
+                }
+                else {
+                    while (--end >= s) {
+                        int i;
+                        if (*end == '_')
+                            continue;
+                        i = (*end - '0');
                         if (   (mult == VERSION_MAX)
-                            || (i > VERSION_MAX / mult)
-                            || (i * mult > VERSION_MAX - rev))
+                                || (i > VERSION_MAX / mult)
+                                || (i * mult > VERSION_MAX - rev))
                         {
-			    Perl_ck_warner(aTHX_ packWARN(WARN_OVERFLOW), 
-					   "Integer overflow in version");
-			    end = s - 1;
-			    rev = VERSION_MAX;
-			    vinf = 1;
-			}
+                            Perl_ck_warner(aTHX_ packWARN(WARN_OVERFLOW), 
+                                    "Integer overflow in version");
+                            end = s - 1;
+                            rev = VERSION_MAX;
+                            vinf = 1;
+                        }
                         else
                             rev += i * mult;
 
@@ -367,79 +367,79 @@ Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv)
                             mult = VERSION_MAX;
                         else
                             mult *= 10;
- 		    }
- 		} 
-  	    }
+                    }
+                } 
+            }
 
-  	    /* Append revision */
-	    av_push(av, newSViv(rev));
-	    if ( vinf ) {
-		s = last;
-		break;
-	    }
-	    else if ( *pos == '.' ) {
-		pos++;
-		if (qv) {
-		    while (*pos == '0')
-			++pos;
-		}
-		s = pos;
-	    }
-	    else if ( *pos == '_' && isDIGIT(pos[1]) )
-		s = ++pos;
-	    else if ( *pos == ',' && isDIGIT(pos[1]) )
-		s = ++pos;
-	    else if ( isDIGIT(*pos) )
-		s = pos;
-	    else {
-		s = pos;
-		break;
-	    }
-	    if ( qv ) {
-		while ( isDIGIT(*pos) || *pos == '_')
-		    pos++;
-	    }
-	    else {
-		int digits = 0;
-		while ( ( isDIGIT(*pos) || *pos == '_' ) && digits < 3 ) {
-		    if ( *pos != '_' )
-			digits++;
-		    pos++;
-		}
-	    }
-	}
+            /* Append revision */
+            av_push(av, newSViv(rev));
+            if ( vinf ) {
+                s = last;
+                break;
+            }
+            else if ( *pos == '.' ) {
+                pos++;
+                if (qv) {
+                    while (*pos == '0')
+                        ++pos;
+                }
+                s = pos;
+            }
+            else if ( *pos == '_' && isDIGIT(pos[1]) )
+                s = ++pos;
+            else if ( *pos == ',' && isDIGIT(pos[1]) )
+                s = ++pos;
+            else if ( isDIGIT(*pos) )
+                s = pos;
+            else {
+                s = pos;
+                break;
+            }
+            if ( qv ) {
+                while ( isDIGIT(*pos) || *pos == '_')
+                    pos++;
+            }
+            else {
+                int digits = 0;
+                while ( ( isDIGIT(*pos) || *pos == '_' ) && digits < 3 ) {
+                    if ( *pos != '_' )
+                        digits++;
+                    pos++;
+                }
+            }
+        }
     }
     if ( qv ) { /* quoted versions always get at least three terms*/
-	SSize_t len = AvFILLp(av);
-	/* This for loop appears to trigger a compiler bug on OS X, as it
-	   loops infinitely. Yes, len is negative. No, it makes no sense.
-	   Compiler in question is:
-	   gcc version 3.3 20030304 (Apple Computer, Inc. build 1640)
-	   for ( len = 2 - len; len > 0; len-- )
-	   av_push(MUTABLE_AV(sv), newSViv(0));
-	*/
-	len = 2 - len;
-	while (len-- > 0)
-	    av_push(av, newSViv(0));
+        SSize_t len = AvFILLp(av);
+        /* This for loop appears to trigger a compiler bug on OS X, as it
+           loops infinitely. Yes, len is negative. No, it makes no sense.
+           Compiler in question is:
+           gcc version 3.3 20030304 (Apple Computer, Inc. build 1640)
+           for ( len = 2 - len; len > 0; len-- )
+           av_push(MUTABLE_AV(sv), newSViv(0));
+           */
+        len = 2 - len;
+        while (len-- > 0)
+            av_push(av, newSViv(0));
     }
 
     /* need to save off the current version string for later */
     if ( vinf ) {
-	SV * orig = newSVpvn("v.Inf", sizeof("v.Inf")-1);
-	(void)hv_stores(MUTABLE_HV(hv), "original", orig);
-	(void)hv_stores(MUTABLE_HV(hv), "vinf", newSViv(1));
+        SV * orig = newSVpvn("v.Inf", sizeof("v.Inf")-1);
+        (void)hv_stores(MUTABLE_HV(hv), "original", orig);
+        (void)hv_stores(MUTABLE_HV(hv), "vinf", newSViv(1));
     }
     else if ( s > start ) {
-	SV * orig = newSVpvn(start,s-start);
-	if ( qv && saw_decimal == 1 && *start != 'v' ) {
-	    /* need to insert a v to be consistent */
-	    sv_insert(orig, 0, 0, "v", 1);
-	}
-	(void)hv_stores(MUTABLE_HV(hv), "original", orig);
+        SV * orig = newSVpvn(start,s-start);
+        if ( qv && saw_decimal == 1 && *start != 'v' ) {
+            /* need to insert a v to be consistent */
+            sv_insert(orig, 0, 0, "v", 1);
+        }
+        (void)hv_stores(MUTABLE_HV(hv), "original", orig);
     }
     else {
-	(void)hv_stores(MUTABLE_HV(hv), "original", newSVpvs("0"));
-	av_push(av, newSViv(0));
+        (void)hv_stores(MUTABLE_HV(hv), "original", newSVpvs("0"));
+        av_push(av, newSViv(0));
     }
 
     /* And finally, store the AV in the hash */
@@ -447,7 +447,7 @@ Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv)
 
     /* fix RT#19517 - special case 'undef' as string */
     if ( *s == 'u' && strEQ(s+1,"ndef") ) {
-	s += 5;
+        s += 5;
     }
 
     return s;
@@ -477,74 +477,74 @@ Perl_new_version(pTHX_ SV *ver)
     PERL_ARGS_ASSERT_NEW_VERSION;
     if ( ISA_VERSION_OBJ(ver) ) /* can just copy directly */
     {
-	SSize_t key;
-	AV * const av = newAV();
-	AV *sav;
-	/* This will get reblessed later if a derived class*/
-	SV * const hv = newSVrv(rv, "version"); 
-	(void)sv_upgrade(hv, SVt_PVHV); /* needs to be an HV type */
+        SSize_t key;
+        AV * const av = newAV();
+        AV *sav;
+        /* This will get reblessed later if a derived class*/
+        SV * const hv = newSVrv(rv, "version"); 
+        (void)sv_upgrade(hv, SVt_PVHV); /* needs to be an HV type */
 #ifndef NODEFAULT_SHAREKEYS
-	HvSHAREKEYS_on(hv);         /* key-sharing on by default */
+        HvSHAREKEYS_on(hv);         /* key-sharing on by default */
 #endif
 
-	if ( SvROK(ver) )
-	    ver = SvRV(ver);
+        if ( SvROK(ver) )
+            ver = SvRV(ver);
 
-	/* Begin copying all of the elements */
-	if ( hv_exists(MUTABLE_HV(ver), "qv", 2) )
-	    (void)hv_stores(MUTABLE_HV(hv), "qv", newSViv(1));
+        /* Begin copying all of the elements */
+        if ( hv_exists(MUTABLE_HV(ver), "qv", 2) )
+            (void)hv_stores(MUTABLE_HV(hv), "qv", newSViv(1));
 
-	if ( hv_exists(MUTABLE_HV(ver), "alpha", 5) )
-	    (void)hv_stores(MUTABLE_HV(hv), "alpha", newSViv(1));
-	{
-	    SV ** svp = hv_fetchs(MUTABLE_HV(ver), "width", FALSE);
-	    if(svp) {
-		const I32 width = SvIV(*svp);
-		(void)hv_stores(MUTABLE_HV(hv), "width", newSViv(width));
-	    }
-	}
-	{
-	    SV ** svp = hv_fetchs(MUTABLE_HV(ver), "original", FALSE);
-	    if(svp)
-		(void)hv_stores(MUTABLE_HV(hv), "original", newSVsv(*svp));
-	}
-	sav = MUTABLE_AV(SvRV(*hv_fetchs(MUTABLE_HV(ver), "version", FALSE)));
-	/* This will get reblessed later if a derived class*/
-	for ( key = 0; key <= av_len(sav); key++ )
-	{
-	    SV * const sv = *av_fetch(sav, key, FALSE);
-	    const I32 rev = SvIV(sv);
-	    av_push(av, newSViv(rev));
-	}
+        if ( hv_exists(MUTABLE_HV(ver), "alpha", 5) )
+            (void)hv_stores(MUTABLE_HV(hv), "alpha", newSViv(1));
+        {
+            SV ** svp = hv_fetchs(MUTABLE_HV(ver), "width", FALSE);
+            if(svp) {
+                const I32 width = SvIV(*svp);
+                (void)hv_stores(MUTABLE_HV(hv), "width", newSViv(width));
+            }
+        }
+        {
+            SV ** svp = hv_fetchs(MUTABLE_HV(ver), "original", FALSE);
+            if(svp)
+                (void)hv_stores(MUTABLE_HV(hv), "original", newSVsv(*svp));
+        }
+        sav = MUTABLE_AV(SvRV(*hv_fetchs(MUTABLE_HV(ver), "version", FALSE)));
+        /* This will get reblessed later if a derived class*/
+        for ( key = 0; key <= av_len(sav); key++ )
+        {
+            SV * const sv = *av_fetch(sav, key, FALSE);
+            const I32 rev = SvIV(sv);
+            av_push(av, newSViv(rev));
+        }
 
-	(void)hv_stores(MUTABLE_HV(hv), "version", newRV_noinc(MUTABLE_SV(av)));
-	return rv;
+        (void)hv_stores(MUTABLE_HV(hv), "version", newRV_noinc(MUTABLE_SV(av)));
+        return rv;
     }
 #ifdef SvVOK
     {
-	const MAGIC* const mg = SvVSTRING_mg(ver);
-	if ( mg ) { /* already a v-string */
-	    const STRLEN len = mg->mg_len;
-	    const char * const version = (const char*)mg->mg_ptr;
-	    char *raw, *under;
-	    static const char underscore[] = "_";
-	    sv_setpvn(rv,version,len);
-	    raw = SvPV_nolen(rv);
-	    under = ninstr(raw, raw+len, underscore, underscore + 1);
-	    if (under) {
-		Move(under + 1, under, raw + len - under - 1, char);
-		SvCUR_set(rv, SvCUR(rv) - 1);
-		*SvEND(rv) = '\0';
-	    }
-	    /* this is for consistency with the pure Perl class */
-	    if ( isDIGIT(*version) )
-		sv_insert(rv, 0, 0, "v", 1);
-	}
-	else {
+        const MAGIC* const mg = SvVSTRING_mg(ver);
+        if ( mg ) { /* already a v-string */
+            const STRLEN len = mg->mg_len;
+            const char * const version = (const char*)mg->mg_ptr;
+            char *raw, *under;
+            static const char underscore[] = "_";
+            sv_setpvn(rv,version,len);
+            raw = SvPV_nolen(rv);
+            under = ninstr(raw, raw+len, underscore, underscore + 1);
+            if (under) {
+                Move(under + 1, under, raw + len - under - 1, char);
+                SvCUR_set(rv, SvCUR(rv) - 1);
+                *SvEND(rv) = '\0';
+            }
+            /* this is for consistency with the pure Perl class */
+            if ( isDIGIT(*version) )
+                sv_insert(rv, 0, 0, "v", 1);
+        }
+        else {
 #endif
-	SvSetSV_nosteal(rv, ver); /* make a duplicate */
+            SvSetSV_nosteal(rv, ver); /* make a duplicate */
 #ifdef SvVOK
-	}
+        }
     }
 #endif
     sv_2mortal(rv); /* in case upg_version croaks before it returns */
@@ -582,45 +582,45 @@ Perl_upg_version(pTHX_ SV *ver, bool qv)
     PERL_ARGS_ASSERT_UPG_VERSION;
 
     if ( (SvUOK(ver) && SvUVX(ver) > VERSION_MAX)
-	   || (SvIOK(ver) && SvIVX(ver) > VERSION_MAX) ) {
-	/* out of bounds [unsigned] integer */
-	STRLEN len;
-	char tbuf[64];
-	len = my_snprintf(tbuf, sizeof(tbuf), "%d", VERSION_MAX);
-	version = savepvn(tbuf, len);
-	SAVEFREEPV(version);
-	Perl_ck_warner(aTHX_ packWARN(WARN_OVERFLOW),
-		       "Integer overflow in version %d",VERSION_MAX);
+            || (SvIOK(ver) && SvIVX(ver) > VERSION_MAX) ) {
+        /* out of bounds [unsigned] integer */
+        STRLEN len;
+        char tbuf[64];
+        len = my_snprintf(tbuf, sizeof(tbuf), "%d", VERSION_MAX);
+        version = savepvn(tbuf, len);
+        SAVEFREEPV(version);
+        Perl_ck_warner(aTHX_ packWARN(WARN_OVERFLOW),
+                "Integer overflow in version %d",VERSION_MAX);
     }
     else if ( SvUOK(ver) || SvIOK(ver))
 #if PERL_VERSION_LT(5,17,2)
 VER_IV:
 #endif
     {
-	version = savesvpv(ver);
-	SAVEFREEPV(version);
+        version = savesvpv(ver);
+        SAVEFREEPV(version);
     }
     else if (SvNOK(ver) && !( SvPOK(ver) && SvCUR(ver) == 3 ) )
 #if PERL_VERSION_LT(5,17,2)
 VER_NV:
 #endif
     {
-	STRLEN len;
+        STRLEN len;
 
-	/* may get too much accuracy */ 
-	char tbuf[64];
-	SV *sv = SvNVX(ver) > 10e50 ? newSV(64) : 0;
-	char *buf;
+        /* may get too much accuracy */ 
+        char tbuf[64];
+        SV *sv = SvNVX(ver) > 10e50 ? newSV(64) : 0;
+        char *buf;
 
 #if PERL_VERSION_GE(5,19,0)
-	if (SvPOK(ver)) {
-	    /* dualvar? */
-	    goto VER_PV;
-	}
+        if (SvPOK(ver)) {
+            /* dualvar? */
+            goto VER_PV;
+        }
 #endif
 #ifdef USE_LOCALE_NUMERIC
 
-	{
+        {
             /* This may or may not be called from code that has switched
              * locales without letting perl know, therefore we have to find it
              * from first principals.  See [perl #121930]. */
@@ -670,8 +670,8 @@ VER_NV:
                 else {  /* This value indicates to the restore code that we
                            didn't change the locale */
                     locale_name_on_entry = NULL;
-	    }
-	}
+                }
+            }
             else if (locale_obj_on_entry == PL_underlying_numeric_obj) {
                 /* Here, the locale appears to have been changed to use the
                  * program's underlying locale.  Just use our mechanisms to
@@ -696,15 +696,15 @@ VER_NV:
 
 #endif
 
-	if (sv) {
+            if (sv) {
                 Perl_sv_setpvf(aTHX_ sv, "%.9" NVff, SvNVX(ver));
-	    len = SvCUR(sv);
-	    buf = SvPVX(sv);
-	}
-	else {
+                len = SvCUR(sv);
+                buf = SvPVX(sv);
+            }
+            else {
                 len = my_snprintf(tbuf, sizeof(tbuf), "%.9" NVff, SvNVX(ver));
-	    buf = tbuf;
-	}
+                buf = tbuf;
+            }
 
 #ifdef USE_LOCALE_NUMERIC
 
@@ -739,82 +739,82 @@ VER_NV:
 
 #endif  /* USE_LOCALE_NUMERIC */
 
-	while (buf[len-1] == '0' && len > 0) len--;
-	if ( buf[len-1] == '.' ) len--; /* eat the trailing decimal */
-	version = savepvn(buf, len);
-	SAVEFREEPV(version);
-	SvREFCNT_dec(sv);
+        while (buf[len-1] == '0' && len > 0) len--;
+        if ( buf[len-1] == '.' ) len--; /* eat the trailing decimal */
+        version = savepvn(buf, len);
+        SAVEFREEPV(version);
+        SvREFCNT_dec(sv);
     }
 #ifdef SvVOK
     else if ( (mg = SvVSTRING_mg(ver)) ) { /* already a v-string */
-	version = savepvn( (const char*)mg->mg_ptr,mg->mg_len );
-	SAVEFREEPV(version);
-	qv = TRUE;
+        version = savepvn( (const char*)mg->mg_ptr,mg->mg_len );
+        SAVEFREEPV(version);
+        qv = TRUE;
     }
 #endif
     else if ( SvPOK(ver))/* must be a string or something like a string */
 VER_PV:
     {
-	STRLEN len;
-	version = savepvn(SvPV(ver,len), SvCUR(ver));
-	SAVEFREEPV(version);
+        STRLEN len;
+        version = savepvn(SvPV(ver,len), SvCUR(ver));
+        SAVEFREEPV(version);
 #ifndef SvVOK
-	/* This will only be executed for 5.6.0 - 5.8.0 inclusive */
-	if ( len >= 3 && !instr(version,".") && !instr(version,"_")) {
-	    /* may be a v-string */
-	    char *testv = (char *)version;
-	    STRLEN tlen = len;
-	    for (tlen=0; tlen < len; tlen++, testv++) {
-		/* if one of the characters is non-text assume v-string */
-		if (testv[0] < ' ') {
-		    SV * const nsv = sv_newmortal();
-		    const char *nver;
-		    const char *pos;
-		    int saw_decimal = 0;
-		    sv_setpvf(nsv,"v%vd",ver);
-		    pos = nver = savepv(SvPV_nolen(nsv));
+        /* This will only be executed for 5.6.0 - 5.8.0 inclusive */
+        if ( len >= 3 && !instr(version,".") && !instr(version,"_")) {
+            /* may be a v-string */
+            char *testv = (char *)version;
+            STRLEN tlen = len;
+            for (tlen=0; tlen < len; tlen++, testv++) {
+                /* if one of the characters is non-text assume v-string */
+                if (testv[0] < ' ') {
+                    SV * const nsv = sv_newmortal();
+                    const char *nver;
+                    const char *pos;
+                    int saw_decimal = 0;
+                    sv_setpvf(nsv,"v%vd",ver);
+                    pos = nver = savepv(SvPV_nolen(nsv));
                     SAVEFREEPV(pos);
 
-		    /* scan the resulting formatted string */
-		    pos++; /* skip the leading 'v' */
-		    while ( *pos == '.' || isDIGIT(*pos) ) {
-			if ( *pos == '.' )
-			    saw_decimal++ ;
-			pos++;
-		    }
+                    /* scan the resulting formatted string */
+                    pos++; /* skip the leading 'v' */
+                    while ( *pos == '.' || isDIGIT(*pos) ) {
+                        if ( *pos == '.' )
+                            saw_decimal++ ;
+                        pos++;
+                    }
 
-		    /* is definitely a v-string */
-		    if ( saw_decimal >= 2 ) {
-			version = nver;
-		    }
-		    break;
-		}
-	    }
-	}
+                    /* is definitely a v-string */
+                    if ( saw_decimal >= 2 ) {
+                        version = nver;
+                    }
+                    break;
+                }
+            }
+        }
 #endif
     }
 #if PERL_VERSION_LT(5,17,2)
     else if (SvIOKp(ver)) {
-	goto VER_IV;
+        goto VER_IV;
     }
     else if (SvNOKp(ver)) {
-	goto VER_NV;
+        goto VER_NV;
     }
     else if (SvPOKp(ver)) {
-	goto VER_PV;
+        goto VER_PV;
     }
 #endif
     else
     {
-	/* no idea what this is */
-	Perl_croak(aTHX_ "Invalid version format (non-numeric data)");
+        /* no idea what this is */
+        Perl_croak(aTHX_ "Invalid version format (non-numeric data)");
     }
 
     s = SCAN_VERSION(version, ver, qv);
     if ( *s != '\0' ) 
-	Perl_ck_warner(aTHX_ packWARN(WARN_MISC), 
-		       "Version string '%s' contains invalid data; "
-		       "ignoring: '%s'", version, s);
+        Perl_ck_warner(aTHX_ packWARN(WARN_MISC), 
+                "Version string '%s' contains invalid data; "
+                "ignoring: '%s'", version, s);
 
 #if PERL_VERSION_LT(5,19,8) && defined(USE_ITHREADS)
     LEAVE;
@@ -862,16 +862,16 @@ Perl_vverify(pTHX_ SV *vs)
     PERL_ARGS_ASSERT_VVERIFY;
 
     if ( SvROK(vs) )
-	vs = SvRV(vs);
+        vs = SvRV(vs);
 
     /* see if the appropriate elements exist */
     if ( SvTYPE(vs) == SVt_PVHV
-	 && (svp = hv_fetchs(MUTABLE_HV(vs), "version", FALSE))
-	 && (sv = SvRV(*svp))
-	 && SvTYPE(sv) == SVt_PVAV )
-	return vs;
+            && (svp = hv_fetchs(MUTABLE_HV(vs), "version", FALSE))
+            && (sv = SvRV(*svp))
+            && SvTYPE(sv) == SVt_PVAV )
+        return vs;
     else
-	return NULL;
+        return NULL;
 }
 
 /*
@@ -908,42 +908,42 @@ Perl_vnumify(pTHX_ SV *vs)
     /* extract the HV from the object */
     vs = VVERIFY(vs);
     if ( ! vs )
-	Perl_croak(aTHX_ "Invalid version object");
+        Perl_croak(aTHX_ "Invalid version object");
 
     /* see if various flags exist */
     if ( hv_exists(MUTABLE_HV(vs), "alpha", 5 ) )
-	alpha = TRUE;
+        alpha = TRUE;
 
     if (alpha) {
-	Perl_ck_warner(aTHX_ packWARN(WARN_NUMERIC),
-		       "alpha->numify() is lossy");
+        Perl_ck_warner(aTHX_ packWARN(WARN_NUMERIC),
+                "alpha->numify() is lossy");
     }
 
     /* attempt to retrieve the version array */
     if ( !(av = MUTABLE_AV(SvRV(*hv_fetchs(MUTABLE_HV(vs), "version", FALSE))) ) ) {
-	return newSVpvs("0");
+        return newSVpvs("0");
     }
 
     len = av_len(av);
     if ( len == -1 )
     {
-	return newSVpvs("0");
+        return newSVpvs("0");
     }
 
     {
-	SV * tsv = *av_fetch(av, 0, 0);
-	digit = SvIV(tsv);
+        SV * tsv = *av_fetch(av, 0, 0);
+        digit = SvIV(tsv);
     }
     sv = Perl_newSVpvf(aTHX_ "%d.", (int)PERL_ABS(digit));
     for ( i = 1 ; i <= len ; i++ )
     {
-	SV * tsv = *av_fetch(av, i, 0);
-	digit = SvIV(tsv);
-	Perl_sv_catpvf(aTHX_ sv, "%03d", (int)digit);
+        SV * tsv = *av_fetch(av, i, 0);
+        digit = SvIV(tsv);
+        Perl_sv_catpvf(aTHX_ sv, "%03d", (int)digit);
     }
 
     if ( len == 0 ) {
-	sv_catpvs(sv, "000");
+        sv_catpvs(sv, "000");
     }
     return sv;
 }
@@ -980,29 +980,29 @@ Perl_vnormal(pTHX_ SV *vs)
     /* extract the HV from the object */
     vs = VVERIFY(vs);
     if ( ! vs )
-	Perl_croak(aTHX_ "Invalid version object");
+        Perl_croak(aTHX_ "Invalid version object");
 
     av = MUTABLE_AV(SvRV(*hv_fetchs(MUTABLE_HV(vs), "version", FALSE)));
 
     len = av_len(av);
     if ( len == -1 )
     {
-	return newSVpvs("");
+        return newSVpvs("");
     }
     {
-	SV * tsv = *av_fetch(av, 0, 0);
-	digit = SvIV(tsv);
+        SV * tsv = *av_fetch(av, 0, 0);
+        digit = SvIV(tsv);
     }
     sv = Perl_newSVpvf(aTHX_ "v%" IVdf, (IV)digit);
     for ( i = 1 ; i <= len ; i++ ) {
-	SV * tsv = *av_fetch(av, i, 0);
-	digit = SvIV(tsv);
-	Perl_sv_catpvf(aTHX_ sv, ".%" IVdf, (IV)digit);
+        SV * tsv = *av_fetch(av, i, 0);
+        digit = SvIV(tsv);
+        Perl_sv_catpvf(aTHX_ sv, ".%" IVdf, (IV)digit);
     }
 
     if ( len <= 2 ) { /* short version, must be at least three */
-	for ( len = 2 - len; len != 0; len-- )
-	    sv_catpvs(sv,".0");
+        for ( len = 2 - len; len != 0; len-- )
+            sv_catpvs(sv,".0");
     }
     return sv;
 }
@@ -1033,26 +1033,26 @@ Perl_vstringify(pTHX_ SV *vs)
     /* extract the HV from the object */
     vs = VVERIFY(vs);
     if ( ! vs )
-	Perl_croak(aTHX_ "Invalid version object");
+        Perl_croak(aTHX_ "Invalid version object");
 
     svp = hv_fetchs(MUTABLE_HV(vs), "original", FALSE);
     if (svp) {
-	SV *pv;
-	pv = *svp;
-	if ( SvPOK(pv)
+        SV *pv;
+        pv = *svp;
+        if ( SvPOK(pv)
 #if PERL_VERSION_LT(5,17,2)
-	    || SvPOKp(pv)
+                || SvPOKp(pv)
 #endif
-	)
-	    return newSVsv(pv);
-	else
-	    return &PL_sv_undef;
+           )
+            return newSVsv(pv);
+        else
+            return &PL_sv_undef;
     }
     else {
-	if ( hv_exists(MUTABLE_HV(vs), "qv", 2) )
-	    return VNORMAL(vs);
-	else
-	    return VNUMIFY(vs);
+        if ( hv_exists(MUTABLE_HV(vs), "qv", 2) )
+            return VNORMAL(vs);
+        else
+            return VNUMIFY(vs);
     }
 }
 
@@ -1084,7 +1084,7 @@ Perl_vcmp(pTHX_ SV *lhv, SV *rhv)
     lhv = VVERIFY(lhv);
     rhv = VVERIFY(rhv);
     if ( ! ( lhv && rhv ) )
-	Perl_croak(aTHX_ "Invalid version object");
+        Perl_croak(aTHX_ "Invalid version object");
 
     /* get the left hand term */
     lav = MUTABLE_AV(SvRV(*hv_fetchs(MUTABLE_HV(lhv), "version", FALSE)));
@@ -1099,40 +1099,40 @@ Perl_vcmp(pTHX_ SV *lhv, SV *rhv)
     i = 0;
     while ( i <= m && retval == 0 )
     {
-	SV * const lsv = *av_fetch(lav,i,0);
-	SV * rsv;
-	left = SvIV(lsv);
-	rsv = *av_fetch(rav,i,0);
-	right = SvIV(rsv);
-	if ( left < right  )
-	    retval = -1;
-	if ( left > right )
-	    retval = +1;
-	i++;
+        SV * const lsv = *av_fetch(lav,i,0);
+        SV * rsv;
+        left = SvIV(lsv);
+        rsv = *av_fetch(rav,i,0);
+        right = SvIV(rsv);
+        if ( left < right  )
+            retval = -1;
+        if ( left > right )
+            retval = +1;
+        i++;
     }
 
     if ( l != r && retval == 0 ) /* possible match except for trailing 0's */
     {
-	if ( l < r )
-	{
-	    while ( i <= r && retval == 0 )
-	    {
-		SV * const rsv = *av_fetch(rav,i,0);
-		if ( SvIV(rsv) != 0 )
-		    retval = -1; /* not a match after all */
-		i++;
-	    }
-	}
-	else
-	{
-	    while ( i <= l && retval == 0 )
-	    {
-		SV * const lsv = *av_fetch(lav,i,0);
-		if ( SvIV(lsv) != 0 )
-		    retval = +1; /* not a match after all */
-		i++;
-	    }
-	}
+        if ( l < r )
+        {
+            while ( i <= r && retval == 0 )
+            {
+                SV * const rsv = *av_fetch(rav,i,0);
+                if ( SvIV(rsv) != 0 )
+                    retval = -1; /* not a match after all */
+                i++;
+            }
+        }
+        else
+        {
+            while ( i <= l && retval == 0 )
+            {
+                SV * const lsv = *av_fetch(lav,i,0);
+                if ( SvIV(lsv) != 0 )
+                    retval = +1; /* not a match after all */
+                i++;
+            }
+        }
     }
     return retval;
 }

--- a/vutil/vutil.h
+++ b/vutil/vutil.h
@@ -31,21 +31,21 @@ static SV * Perl_vstringify2(pTHX_ SV *vs);
 static int Perl_vcmp2(pTHX_ SV *lsv, SV *rsv);
 static const char * Perl_prescan_version2(pTHX_ const char *s, bool strict, const char** errstr, bool *sqv, int *ssaw_decimal, int *swidth, bool *salpha);
 
-#  define SCAN_VERSION(a,b,c)	Perl_scan_version2(aTHX_ a,b,c)
-#  define NEW_VERSION(a)	Perl_new_version2(aTHX_ a)
-#  define UPG_VERSION(a,b)	Perl_upg_version2(aTHX_ a, b)
-#  define VSTRINGIFY(a)		Perl_vstringify2(aTHX_ a)
-#  define VVERIFY(a)		Perl_vverify2(aTHX_ a)
-#  define VNUMIFY(a)		Perl_vnumify2(aTHX_ a)
-#  define VNORMAL(a)		Perl_vnormal2(aTHX_ a)
-#  define VCMP(a,b)		Perl_vcmp2(aTHX_ a,b)
-#  define PRESCAN_VERSION(a,b,c,d,e,f,g)	Perl_prescan_version2(aTHX_ a,b,c,d,e,f,g)
+#  define SCAN_VERSION(a,b,c)   Perl_scan_version2(aTHX_ a,b,c)
+#  define NEW_VERSION(a)        Perl_new_version2(aTHX_ a)
+#  define UPG_VERSION(a,b)      Perl_upg_version2(aTHX_ a, b)
+#  define VSTRINGIFY(a)         Perl_vstringify2(aTHX_ a)
+#  define VVERIFY(a)            Perl_vverify2(aTHX_ a)
+#  define VNUMIFY(a)            Perl_vnumify2(aTHX_ a)
+#  define VNORMAL(a)            Perl_vnormal2(aTHX_ a)
+#  define VCMP(a,b)             Perl_vcmp2(aTHX_ a,b)
+#  define PRESCAN_VERSION(a,b,c,d,e,f,g)    Perl_prescan_version2(aTHX_ a,b,c,d,e,f,g)
 #  undef is_LAX_VERSION
 #  define is_LAX_VERSION(a,b) \
-	(a != Perl_prescan_version2(aTHX_ a, FALSE, b, NULL, NULL, NULL, NULL))
+        (a != Perl_prescan_version2(aTHX_ a, FALSE, b, NULL, NULL, NULL, NULL))
 #  undef is_STRICT_VERSION
 #  define is_STRICT_VERSION(a,b) \
-	(a != Perl_prescan_version2(aTHX_ a, TRUE, b, NULL, NULL, NULL, NULL))
+        (a != Perl_prescan_version2(aTHX_ a, TRUE, b, NULL, NULL, NULL, NULL))
 
 #else
 
@@ -59,56 +59,56 @@ SV * Perl_vstringify(pTHX_ SV *vs);
 int Perl_vcmp(pTHX_ SV *lsv, SV *rsv);
 const char * Perl_prescan_version(pTHX_ const char *s, bool strict, const char** errstr, bool *sqv, int *ssaw_decimal, int *swidth, bool *salpha);
 
-#  define SCAN_VERSION(a,b,c)	Perl_scan_version(aTHX_ a,b,c)
-#  define NEW_VERSION(a)	Perl_new_version(aTHX_ a)
-#  define UPG_VERSION(a,b)	Perl_upg_version(aTHX_ a, b)
-#  define VSTRINGIFY(a)		Perl_vstringify(aTHX_ a)
-#  define VVERIFY(a)		Perl_vverify(aTHX_ a)
-#  define VNUMIFY(a)		Perl_vnumify(aTHX_ a)
-#  define VNORMAL(a)		Perl_vnormal(aTHX_ a)
-#  define VCMP(a,b)		Perl_vcmp(aTHX_ a,b)
+#  define SCAN_VERSION(a,b,c)   Perl_scan_version(aTHX_ a,b,c)
+#  define NEW_VERSION(a)        Perl_new_version(aTHX_ a)
+#  define UPG_VERSION(a,b)      Perl_upg_version(aTHX_ a, b)
+#  define VSTRINGIFY(a)         Perl_vstringify(aTHX_ a)
+#  define VVERIFY(a)            Perl_vverify(aTHX_ a)
+#  define VNUMIFY(a)            Perl_vnumify(aTHX_ a)
+#  define VNORMAL(a)            Perl_vnormal(aTHX_ a)
+#  define VCMP(a,b)             Perl_vcmp(aTHX_ a,b)
 
-#  define PRESCAN_VERSION(a,b,c,d,e,f,g)	Perl_prescan_version(aTHX_ a,b,c,d,e,f,g)
+#  define PRESCAN_VERSION(a,b,c,d,e,f,g)    Perl_prescan_version(aTHX_ a,b,c,d,e,f,g)
 #  ifndef is_LAX_VERSION
 #    define is_LAX_VERSION(a,b) \
-	(a != Perl_prescan_version(aTHX_ a, FALSE, b, NULL, NULL, NULL, NULL))
+        (a != Perl_prescan_version(aTHX_ a, FALSE, b, NULL, NULL, NULL, NULL))
 #  endif
 #  ifndef is_STRICT_VERSION
 #    define is_STRICT_VERSION(a,b) \
-	(a != Perl_prescan_version(aTHX_ a, TRUE, b, NULL, NULL, NULL, NULL))
+        (a != Perl_prescan_version(aTHX_ a, TRUE, b, NULL, NULL, NULL, NULL))
 #  endif
 
 #endif
 
 #if PERL_VERSION_LT(5,11,4)
 #  define BADVERSION(a,b,c) \
-	if (b) { \
-	    *b = c; \
-	} \
-	return a;
+        if (b) { \
+            *b = c; \
+        } \
+        return a;
 
-#  define PERL_ARGS_ASSERT_PRESCAN_VERSION	\
-	assert(s); assert(sqv); assert(ssaw_decimal);\
-	assert(swidth); assert(salpha);
+#  define PERL_ARGS_ASSERT_PRESCAN_VERSION \
+        assert(s); assert(sqv); assert(ssaw_decimal);\
+        assert(swidth); assert(salpha);
 
-#  define PERL_ARGS_ASSERT_SCAN_VERSION	\
-	assert(s); assert(rv)
-#  define PERL_ARGS_ASSERT_NEW_VERSION	\
-	assert(ver)
-#  define PERL_ARGS_ASSERT_UPG_VERSION	\
-	assert(ver)
-#  define PERL_ARGS_ASSERT_VVERIFY	\
-	assert(vs)
-#  define PERL_ARGS_ASSERT_VNUMIFY	\
-	assert(vs)
-#  define PERL_ARGS_ASSERT_VNORMAL	\
-	assert(vs)
-#  define PERL_ARGS_ASSERT_VSTRINGIFY	\
-	assert(vs)
-#  define PERL_ARGS_ASSERT_VCMP	\
-	assert(lhv); assert(rhv)
+#  define PERL_ARGS_ASSERT_SCAN_VERSION \
+        assert(s); assert(rv)
+#  define PERL_ARGS_ASSERT_NEW_VERSION \
+        assert(ver)
+#  define PERL_ARGS_ASSERT_UPG_VERSION \
+        assert(ver)
+#  define PERL_ARGS_ASSERT_VVERIFY \
+        assert(vs)
+#  define PERL_ARGS_ASSERT_VNUMIFY \
+        assert(vs)
+#  define PERL_ARGS_ASSERT_VNORMAL \
+        assert(vs)
+#  define PERL_ARGS_ASSERT_VSTRINGIFY \
+        assert(vs)
+#  define PERL_ARGS_ASSERT_VCMP \
+        assert(lhv); assert(rhv)
 #  define PERL_ARGS_ASSERT_CK_WARNER      \
-	assert(pat)
+        assert(pat)
 #endif
 
 /* ex: set ro: */

--- a/vutil/vxs.inc
+++ b/vutil/vxs.inc
@@ -24,12 +24,12 @@
    PUTBACK; return; */
 
 #define VXS_RETURN_M_SV(sv) \
-    STMT_START {							\
-	SV * sv_vtc = sv;						\
-	PUSHs(sv_vtc);							\
-	PUTBACK;							\
-	sv_2mortal(sv_vtc);						\
-	return;								\
+    STMT_START {                            \
+        SV * sv_vtc = sv;                   \
+        PUSHs(sv_vtc);                      \
+        PUTBACK;                            \
+        sv_2mortal(sv_vtc);                 \
+        return;                             \
     } STMT_END
 
 
@@ -79,14 +79,14 @@
 #ifdef HvNAME_HEK
 typedef HEK HVNAME;
 #  ifndef HEKf
-#    define HEKfARG(arg)	((void*)(sv_2mortal(newSVhek(arg))))
-#    define HEKf		SVf
+#    define HEKfARG(arg)    ((void*)(sv_2mortal(newSVhek(arg))))
+#    define HEKf            SVf
 #  endif
 #else
 typedef char HVNAME;
-#  define HvNAME_HEK	HvNAME_get
-#  define HEKfARG(arg)	arg
-#  define HEKf		"s"
+#  define HvNAME_HEK        HvNAME_get
+#  define HEKfARG(arg)      arg
+#  define HEKf              "s"
 #endif
 
 VXS(universal_version)
@@ -118,8 +118,8 @@ VXS(universal_version)
 
     if (gvp && isGV(gv = *gvp) && (sv = GvSV(gv)) && SvOK(sv)) {
         sv = sv_mortalcopy(sv);
-	if ( ! ISA_VERSION_OBJ(sv) )
-	    UPG_VERSION(sv, FALSE);
+        if ( ! ISA_VERSION_OBJ(sv) )
+            UPG_VERSION(sv, FALSE);
         undef = NULL;
     }
     else {
@@ -128,56 +128,56 @@ VXS(universal_version)
     }
 
     if (items > 1) {
-	SV *req = ST(1);
+        SV *req = ST(1);
 
-	if (undef) {
-	    if (pkg) {
-		const HVNAME* const name = HvNAME_HEK(pkg);
-		Perl_croak(aTHX_
-			   "%" HEKf " does not define $%" HEKf
-			   "::VERSION--version check failed",
-			   HEKfARG(name), HEKfARG(name));
-	    }
-	    else {
+        if (undef) {
+            if (pkg) {
+                const HVNAME* const name = HvNAME_HEK(pkg);
+                Perl_croak(aTHX_
+                      "%" HEKf " does not define $%" HEKf
+                      "::VERSION--version check failed",
+                      HEKfARG(name), HEKfARG(name));
+            }
+            else {
 #if PERL_VERSION_GE(5,8,0)
-		Perl_croak(aTHX_
-			     "%" SVf " defines neither package nor VERSION--"
-                             "version check failed",
-			     (void*)(ST(0)) );
+                Perl_croak(aTHX_
+                      "%" SVf " defines neither package nor VERSION--"
+                      "version check failed",
+                      (void*)(ST(0)) );
 #else
-		Perl_croak(aTHX_ "%s does not define $%s::VERSION--version check failed",
-			   SvPVx_nolen_const(ST(0)),
-			   SvPVx_nolen_const(ST(0)) );
+                Perl_croak(aTHX_ "%s does not define $%s::VERSION--version check failed",
+                      SvPVx_nolen_const(ST(0)),
+                      SvPVx_nolen_const(ST(0)) );
 #endif
-	    }
-	}
+            }
+        }
 
-	if ( ! ISA_VERSION_OBJ(req) ) {
-	    /* req may very well be R/O, so create a new object */
-	    req = sv_2mortal( NEW_VERSION(req) );
-	}
+        if ( ! ISA_VERSION_OBJ(req) ) {
+            /* req may very well be R/O, so create a new object */
+            req = sv_2mortal( NEW_VERSION(req) );
+        }
 
-	if ( VCMP( req, sv ) > 0 ) {
-	    if ( hv_exists(MUTABLE_HV(SvRV(req)), "qv", 2 ) ) {
-		req = VNORMAL(req);
-		sv  = VNORMAL(sv);
-	    }
-	    else {
-		req = VSTRINGIFY(req);
-		sv  = VSTRINGIFY(sv);
-	    }
-	    Perl_croak(aTHX_ "%" HEKf " version %" SVf " required--"
-		"this is only version %" SVf, HEKfARG(HvNAME_HEK(pkg)),
-		SVfARG(sv_2mortal(req)),
-		SVfARG(sv_2mortal(sv)));
-	}
+        if ( VCMP( req, sv ) > 0 ) {
+            if ( hv_exists(MUTABLE_HV(SvRV(req)), "qv", 2 ) ) {
+                req = VNORMAL(req);
+                sv  = VNORMAL(sv);
+            }
+            else {
+                req = VSTRINGIFY(req);
+                sv  = VSTRINGIFY(sv);
+            }
+            Perl_croak(aTHX_ "%" HEKf " version %" SVf " required--"
+                "this is only version %" SVf, HEKfARG(HvNAME_HEK(pkg)),
+                SVfARG(sv_2mortal(req)),
+                SVfARG(sv_2mortal(sv)));
+        }
     }
 
     /* if the package's $VERSION is not undef, it is upgraded to be a version object */
     if (ISA_VERSION_OBJ(sv)) {
-	ST(0) = sv_2mortal(VSTRINGIFY(sv));
+        ST(0) = sv_2mortal(VSTRINGIFY(sv));
     } else {
-	ST(0) = sv;
+        ST(0) = sv;
     }
 
     XSRETURN(1);
@@ -224,17 +224,17 @@ VXS(version_new)
 
     svarg0 = ST(0);
     if ( sv_isobject(svarg0) ) {
-	/* get the class if called as an object method */
-	const HV * stash = SvSTASH(SvRV(svarg0));
-	classname = HvNAME_get(stash);
-	len	  = HvNAMELEN_get(stash);
+        /* get the class if called as an object method */
+        const HV * stash = SvSTASH(SvRV(svarg0));
+        classname = HvNAME_get(stash);
+        len       = HvNAMELEN_get(stash);
 #ifdef HvNAMEUTF8
-	flags	  = HvNAMEUTF8(stash) ? SVf_UTF8 : 0;
+        flags     = HvNAMEUTF8(stash) ? SVf_UTF8 : 0;
 #endif
     }
     else {
-	classname = SvPV_nomg(svarg0, len);
-	flags     = SvUTF8(svarg0);
+        classname = SvPV_nomg(svarg0, len);
+        flags     = SvUTF8(svarg0);
     }
 
     rv = NEW_VERSION(vs);
@@ -246,89 +246,89 @@ VXS(version_new)
 }
 
 #define VTYPECHECK(var, val, varname) \
-    STMT_START {							\
-	SV * sv_vtc = val;						\
-	if (ISA_VERSION_OBJ(sv_vtc)) {				\
-	    (var) = SvRV(sv_vtc);						\
-	}								\
-	else								\
-	    Perl_croak_nocontext(varname " is not of type version");	\
+    STMT_START {                                                        \
+        SV * sv_vtc = val;                                              \
+        if (ISA_VERSION_OBJ(sv_vtc)) {                                  \
+            (var) = SvRV(sv_vtc);                                       \
+        }                                                               \
+        else                                                            \
+            Perl_croak_nocontext(varname " is not of type version");    \
     } STMT_END
 
 VXS(version_stringify)
 {
-     dXSARGS;
-     if (items < 1)
-	 croak_xs_usage(cv, "lobj, ...");
-     SP -= items;
-     {
-	  SV *	lobj;
-	  VTYPECHECK(lobj, ST(0), "lobj");
+    dXSARGS;
+    if (items < 1)
+        croak_xs_usage(cv, "lobj, ...");
+    SP -= items;
+    {
+        SV * lobj;
+        VTYPECHECK(lobj, ST(0), "lobj");
 
-	  VXS_RETURN_M_SV(VSTRINGIFY(lobj));
-     }
+        VXS_RETURN_M_SV(VSTRINGIFY(lobj));
+    }
 }
 
 VXS(version_numify)
 {
-     dXSARGS;
-     if (items < 1)
-	 croak_xs_usage(cv, "lobj, ...");
-     SP -= items;
-     {
-	  SV *	lobj;
-	  VTYPECHECK(lobj, ST(0), "lobj");
-	  VXS_RETURN_M_SV(VNUMIFY(lobj));
-     }
+    dXSARGS;
+    if (items < 1)
+        croak_xs_usage(cv, "lobj, ...");
+    SP -= items;
+    {
+        SV * lobj;
+        VTYPECHECK(lobj, ST(0), "lobj");
+        VXS_RETURN_M_SV(VNUMIFY(lobj));
+    }
 }
 
 VXS(version_normal)
 {
-     dXSARGS;
-     if (items != 1)
-	 croak_xs_usage(cv, "ver");
-     SP -= items;
-     {
-	  SV *	ver;
-	  VTYPECHECK(ver, ST(0), "ver");
+    dXSARGS;
+    if (items != 1)
+        croak_xs_usage(cv, "ver");
+    SP -= items;
+    {
+        SV * ver;
+        VTYPECHECK(ver, ST(0), "ver");
 
-	  VXS_RETURN_M_SV(VNORMAL(ver));
-     }
+        VXS_RETURN_M_SV(VNORMAL(ver));
+    }
 }
 
 VXS(version_vcmp)
 {
-     dXSARGS;
-     if (items < 2)
-	 croak_xs_usage(cv, "lobj, robj, ...");
-     SP -= items;
-     {
-	  SV *	lobj;
-	  VTYPECHECK(lobj, ST(0), "lobj");
-	  {
-	       SV	*rs;
-	       SV	*rvs;
-	       SV * robj = ST(1);
-	       const int swap = items > 2 ? SvTRUE(ST(2)) : 0;
+    dXSARGS;
+    if (items < 2)
+        croak_xs_usage(cv, "lobj, robj, ...");
+    SP -= items;
+    {
+        SV * lobj;
+        VTYPECHECK(lobj, ST(0), "lobj");
+        {
+            SV * rs;
+            SV * rvs;
+            SV * robj = ST(1);
+            const int swap = items > 2 ? SvTRUE(ST(2)) : 0;
 
-	       if ( !ISA_VERSION_OBJ(robj) )
-	       {
-		    robj = sv_2mortal(NEW_VERSION(SvOK(robj) ? robj : newSVpvs_flags("0", SVs_TEMP)));
-	       }
-	       rvs = SvRV(robj);
+            if ( !ISA_VERSION_OBJ(robj) )
+            {
+                robj = sv_2mortal(NEW_VERSION(SvOK(robj) ? robj : newSVpvs_flags("0", SVs_TEMP)));
+            }
+            rvs = SvRV(robj);
 
-	       if ( swap )
-	       {
-		    rs = newSViv(VCMP(rvs,lobj));
-	       }
-	       else
-	       {
-		    rs = newSViv(VCMP(lobj,rvs));
-	       }
+            if ( swap )
+            {
+                rs = newSViv(VCMP(rvs,lobj));
+            }
+            else
+            {
+                rs = newSViv(VCMP(lobj,rvs));
+            }
 
-	       VXS_RETURN_M_SV(rs);
-	  }
-     }
+            VXS_RETURN_M_SV(rs);
+        }
+    }
 }
 
 VXS(version_boolean)
@@ -336,18 +336,17 @@ VXS(version_boolean)
     dXSARGS;
     SV *lobj;
     if (items < 1)
-	croak_xs_usage(cv, "lobj, ...");
+        croak_xs_usage(cv, "lobj, ...");
     SP -= items;
     VTYPECHECK(lobj, ST(0), "lobj");
     {
-	SV * const rs =
-	    newSViv( VCMP(lobj,
-			  sv_2mortal(NEW_VERSION(
-					sv_2mortal(newSVpvs("0"))
-				    ))
-			 )
-		   );
-	VXS_RETURN_M_SV(rs);
+        SV * const rs =
+            newSViv( VCMP(lobj,
+                sv_2mortal(NEW_VERSION(
+                    sv_2mortal(newSVpvs("0"))
+                ))
+            ) );
+        VXS_RETURN_M_SV(rs);
     }
 }
 
@@ -355,11 +354,11 @@ VXS(version_noop)
 {
     dXSARGS;
     if (items < 1)
-	croak_xs_usage(cv, "lobj, ...");
+        croak_xs_usage(cv, "lobj, ...");
     if (ISA_VERSION_OBJ(ST(0)))
-	Perl_croak(aTHX_ "operation not supported with version object");
+        Perl_croak(aTHX_ "operation not supported with version object");
     else
-	Perl_croak(aTHX_ "lobj is not of type version");
+        Perl_croak(aTHX_ "lobj is not of type version");
     XSRETURN_EMPTY;
 }
 
@@ -369,18 +368,18 @@ S_version_check_key(pTHX_ CV * cv, const char * key, int keylen)
 {
     dXSARGS;
     if (items != 1)
-	croak_xs_usage(cv, "lobj");
+        croak_xs_usage(cv, "lobj");
     {
-	SV *lobj = POPs;
-	SV *ret;
-	VTYPECHECK(lobj, lobj, "lobj");
-	if ( hv_exists(MUTABLE_HV(lobj), key, keylen ) )
-	    ret = &PL_sv_yes;
-	else
-	    ret = &PL_sv_no;
-	PUSHs(ret);
-	PUTBACK;
-	return;
+        SV *lobj = POPs;
+        SV *ret;
+        VTYPECHECK(lobj, lobj, "lobj");
+        if ( hv_exists(MUTABLE_HV(lobj), key, keylen ) )
+            ret = &PL_sv_yes;
+        else
+            ret = &PL_sv_no;
+        PUSHs(ret);
+        PUTBACK;
+        return;
     }
 }
 
@@ -395,21 +394,21 @@ VXS(version_qv)
     PERL_UNUSED_ARG(cv);
     SP -= items;
     {
-	SV * ver = ST(0);
-	SV * sv0 = ver;
-	SV * rv;
+        SV * ver = ST(0);
+        SV * sv0 = ver;
+        SV * rv;
         STRLEN len = 0;
         const char * classname = "";
         U32 flags = 0;
         if ( items == 2 ) {
-	    SV * sv1 = ST(1);
-	    SvGETMAGIC(sv1);
-	    if (SvOK(sv1)) {
-		ver = sv1;
-	    }
-	    else {
-		Perl_croak(aTHX_ "Invalid version format (version required)");
-	    }
+            SV * sv1 = ST(1);
+            SvGETMAGIC(sv1);
+            if (SvOK(sv1)) {
+                ver = sv1;
+            }
+            else {
+                Perl_croak(aTHX_ "Invalid version format (version required)");
+            }
             if ( sv_isobject(sv0) ) { /* class called as an object method */
                 const HV * stash = SvSTASH(SvRV(sv0));
                 classname = HvNAME_get(stash);
@@ -419,22 +418,22 @@ VXS(version_qv)
 #endif
             }
             else {
-	       classname = SvPV(sv0, len);
+                classname = SvPV(sv0, len);
                 flags     = SvUTF8(sv0);
             }
-	}
-	if ( !SvVOK(ver) ) { /* not already a v-string */
-	    rv = sv_newmortal();
-	    SvSetSV_nosteal(rv,ver); /* make a duplicate */
-	    UPG_VERSION(rv, TRUE);
-	} else {
-	    rv = sv_2mortal(NEW_VERSION(ver));
-	}
-	if ( items == 2 && (len != 7
-                || strcmp(classname,"version")) ) { /* inherited new() */
-	    sv_bless(rv, gv_stashpvn(classname, len, GV_ADD | flags));
         }
-	PUSHs(rv);
+        if ( !SvVOK(ver) ) { /* not already a v-string */
+            rv = sv_newmortal();
+            SvSetSV_nosteal(rv,ver); /* make a duplicate */
+            UPG_VERSION(rv, TRUE);
+        } else {
+            rv = sv_2mortal(NEW_VERSION(ver));
+        }
+        if ( items == 2 && (len != 7
+                || strcmp(classname,"version")) ) { /* inherited new() */
+            sv_bless(rv, gv_stashpvn(classname, len, GV_ADD | flags));
+        }
+        PUSHs(rv);
     }
     PUTBACK;
     return;

--- a/vutil/vxs.xs
+++ b/vutil/vxs.xs
@@ -47,16 +47,16 @@ VERSIONCHECK: DISABLE
 BOOT:
     {
 #if PERL_VERSION_LT(5,9,0)
-	char* file = __FILE__;
+        char* file = __FILE__;
 #else
-	const char* file = __FILE__;
+        const char* file = __FILE__;
 #endif
-	const struct xsub_details *xsub = details;
-	const struct xsub_details *end
-		= details + sizeof(details) / sizeof(details[0]);
+        const struct xsub_details *xsub = details;
+        const struct xsub_details *end
+            = details + sizeof(details) / sizeof(details[0]);
         /* register the overloading (type 'A') magic */
         PL_amagic_generation++;
-	do {
-	    newXS((char*)xsub->name, xsub->xsub, file);
-	} while (++xsub < end);
+        do {
+            newXS((char*)xsub->name, xsub->xsub, file);
+        } while (++xsub < end);
     }


### PR DESCRIPTION
The indentation was done with a mix of tabs and spaces and was
inconsistent in tons of places. Convert all indentation and inner tabs
to spaces.

ppport.h still has tabs, because it is generated by Devel::PPPort