### PR TITLE
Permit a colon after a vstring (fixes Perl5 #20891)

### DIFF
--- a/vutil/vutil.c
+++ b/vutil/vutil.c
@@ -211,7 +211,7 @@ version_prescan_finish:
     while (isSPACE(*d))
 	d++;
 
-    if (!isDIGIT(*d) && (! (!*d || *d == ';' || *d == '{' || *d == '}') )) {
+    if (!isDIGIT(*d) && (! (!*d || *d == ';' || *d == ':' || *d == '{' || *d == '}') )) {
 	/* trailing non-numeric data */
 	BADVERSION(s,errstr,"Invalid version format (non-numeric data)");
     }


### PR DESCRIPTION
This permits an attrlist to follow a vstring, and therefore allows a version declaration on a 'class' statement to be followed by the attributes for the class

Fixes https://github.com/Perl/perl5/issues/20891