### PR TITLE
fix string comparisons with $] to use numeric comparison instead

### DIFF
--- a/t/coretests.pm
+++ b/t/coretests.pm
@@ -348,7 +348,7 @@ SKIP: 	{
 
 SKIP: 	{
 	skip 'Cannot test bare alpha v-strings with Perl < 5.8.1', 2
-		if $] lt 5.008_001;
+		if "$]" < 5.008_001;
 	$version = $CLASS->$method(v1.2.3_4);
 	$DB::single = 1;
 	is($version, "v1.2.34", '"$version" eq "v1.2.34"');


### PR DESCRIPTION
The fix follows Zefram's suggestion from
https://www.nntp.perl.org/group/perl.perl5.porters/2012/05/msg186846.html

> On older perls, however, $] had a numeric value that was built up using
> floating-point arithmetic, such as 5+0.006+0.000002.  This would not
> necessarily match the conversion of the complete value from string form
> [perl #72210].  You can work around that by explicitly stringifying
> $] (which produces a correct string) and having *that* numify (to a
> correctly-converted floating point value) for comparison.  I cultivate
> the habit of always stringifying $] to work around this, regardless of
> the threshold where the bug was fixed.  So I'd write
>
>     use if "$]" >= 5.014, warnings => "non_unicode";